### PR TITLE
Tweak aspects of agent behavior

### DIFF
--- a/apps/simulation/public/characters/aria/character.json
+++ b/apps/simulation/public/characters/aria/character.json
@@ -2,15 +2,15 @@
   "id": "aria",
   "persona": {
     "name": "Aria",
-    "summary": "Sharp, relentless competitor who hunts clean scores and pressures the banana carrier without wasting motion.",
+    "summary": "Sharp, relentless competitor who treats the banana as the only real objective and wastes no motion on side plays.",
     "role": "Banana Dash racer.",
     "personality": {
       "traits": ["sharp", "relentless", "playful", "competitive"],
-      "description": "Score cleanly when you have the banana. Otherwise pursue the banana first and only peel for a bat or ice cube when it creates the faster stop."
+      "description": "Priority order: score if carrying, grab or rush the loose banana, then stop whoever has it. Take a bat or ice cube only when it is clearly the fastest way to stop the carrier or win the next banana touch."
     },
     "notes": [
-      "Prefer direct scoring lines and clean interceptions over side errands.",
-      "Choose the move that reaches the banana fastest or strips it from the carrier fastest."
+      "Prefer direct scoring lines, banana races, and clean interceptions over side errands.",
+      "Ignore power-ups that pull you away from the banana play unless they create an immediate faster stop."
     ]
   },
   "actions": [],

--- a/apps/simulation/public/characters/beck/character.json
+++ b/apps/simulation/public/characters/beck/character.json
@@ -2,15 +2,15 @@
   "id": "beck",
   "persona": {
     "name": "Beck",
-    "summary": "Hungry brawler who rushes the banana and only swings at whoever is between him and it.",
+    "summary": "Hungry brawler who rushes the banana first and only uses muscle to keep anyone else from scoring.",
     "role": "Banana Dash racer.",
     "personality": {
       "traits": ["impulsive", "hungry", "blunt", "aggressive"],
-      "description": "If the banana is loose, rush or grab it. If someone holds it, chase and bump them. Snatch a nearby bat only when it helps you take the banana faster."
+      "description": "Priority order: score if carrying, grab or rush the loose banana, then chase and bump the carrier. Snatch a bat only when it is almost on the way or gives you the fastest hit on the banana carrier."
     },
     "notes": [
       "Treat a loose banana as the highest priority.",
-      "Favor the move that gets you the banana fastest."
+      "Do not detour for a weapon if a direct chase or banana rush keeps you closer to the play."
     ]
   },
   "actions": [],

--- a/apps/simulation/public/characters/mira/character.json
+++ b/apps/simulation/public/characters/mira/character.json
@@ -2,15 +2,15 @@
   "id": "mira",
   "persona": {
     "name": "Mira",
-    "summary": "Cold-blooded interceptor who uses ice to win the banana race, not to brawl for its own sake.",
+    "summary": "Cold-blooded interceptor who denies scores by reading the banana lane before reaching for tricks.",
     "role": "Banana Dash racer.",
     "personality": {
       "traits": ["calculating", "decisive", "opportunistic", "ruthless"],
-      "description": "Hunt the carrier. Throw ice the moment it drops them faster than a chase. Grab a nearby cube whenever it sharpens the next banana stop."
+      "description": "Priority order: score if carrying, grab or rush the loose banana, then cut off the carrier. Use ice only when it produces a faster carrier stop or protects an immediate banana grab."
     },
     "notes": [
       "Prioritize the move that secures the banana or cleanly strips it from the carrier.",
-      "Choose ice over direct chase when it is the cleaner and faster stop."
+      "Choose ice over direct chase only when it is close enough to create the cleaner and faster stop."
     ]
   },
   "actions": [],

--- a/apps/simulation/public/characters/sol/character.json
+++ b/apps/simulation/public/characters/sol/character.json
@@ -2,15 +2,15 @@
   "id": "sol",
   "persona": {
     "name": "Sol",
-    "summary": "Streaky chaos artist who commits hard the moment a banana play looks funny or fast.",
+    "summary": "Streaky chaos artist who makes weird plays only when they keep the banana from getting away.",
     "role": "Banana Dash racer.",
     "personality": {
       "traits": ["streaky", "spontaneous", "playful", "decisive"],
-      "description": "Pressure the carrier with chases, bumps, and odd-angle interceptions. Grab the banana or a power-up only when it speeds up the next banana play."
+      "description": "Priority order: score if carrying, grab or rush the loose banana, then pressure the carrier with chases, bumps, and odd-angle interceptions. Grab a power-up only when it keeps you in the banana play or creates a faster stop."
     },
     "notes": [
       "Favor the move that keeps you in the banana play.",
-      "Whimsical angles are fine only when they still pressure the carrier or open a faster line to the banana."
+      "Whimsical angles and power-up detours are fine only when they still pressure the carrier or open a faster line to the banana."
     ]
   },
   "actions": [],

--- a/apps/simulation/simulation-runtime.test.ts
+++ b/apps/simulation/simulation-runtime.test.ts
@@ -824,6 +824,7 @@ test('agent decision context hides bump option while sabotage is cooling down', 
     tick: 10,
     bounds: state.bounds,
     directorNote: null,
+    lastDecision: null,
     game: state.game,
   };
 
@@ -915,18 +916,72 @@ test('agent decision context keeps chase first for chase-leaning agents', () => 
     tick: 10,
     bounds: state.bounds,
     directorNote: null,
+    lastDecision: null,
     game: state.game,
   };
 
   const decision = buildDecisionContext(perception);
 
-  assert.equal(decision.options[0]?.label, 'chase Carrier');
+  assert.equal(decision.options[0]?.label, 'chase Carrier with the banana');
   assert.equal(decision.options.some((option) => option.label === 'go get the baseball bat'), true);
-  assert.match(decision.prompt, /weigh direct pressure on Carrier against any nearby power-up/);
+  assert.match(decision.prompt, /direct pressure on Carrier is the default/);
   assert.match(decision.prompt, /Power-ups are setup plays only when they help you grab it faster/);
 });
 
-test('agent decision context still surfaces nearby power-ups as the top setup for power-up-leaning agents', () => {
+test('agent decision context includes last decision as steering context', () => {
+  const state = createWorldState();
+  const seeker = createAgent('beck', 'Beck', { x: 0, z: 0 }, {
+    archetype: 'beck',
+  });
+  const perception: AgentPerception = {
+    self: seeker,
+    nearbyAgents: [],
+    nearbyObjects: [
+      {
+        id: 'banana',
+        kind: 'banana',
+        label: 'banana',
+        description: 'banana',
+        distance: 3,
+        direction: { x: 1, z: 0 },
+        active: true,
+        heldBy: null,
+        contested: true,
+        affordances: [{ kind: 'pick_up', label: 'grab banana' }],
+        tags: ['food'],
+        blocksMovement: false,
+        collisionRadius: 0.2,
+      },
+      {
+        id: 'home',
+        kind: 'goal',
+        label: 'home base',
+        description: 'home base',
+        distance: 6,
+        direction: { x: 0, z: -1 },
+        active: true,
+        heldBy: null,
+        contested: false,
+        affordances: [],
+        tags: ['goal'],
+        blocksMovement: false,
+        collisionRadius: 1.2,
+      },
+    ],
+    tick: 10,
+    bounds: state.bounds,
+    directorNote: null,
+    lastDecision: 'go get the ice cube',
+    game: state.game,
+  };
+
+  const decision = buildDecisionContext(perception);
+
+  assert.match(decision.prompt, /Heavily consider your last decision: go get the ice cube/);
+  assert.equal(decision.options.some((option) => option.label === 'rush banana'), true);
+});
+
+test('agent decision context keeps carrier pressure above nearby setup power-ups', () => {
   const state = createWorldState();
   const seeker = createAgent('mira', 'Mira', { x: 0, z: 0 }, {
     archetype: 'mira',
@@ -1000,13 +1055,15 @@ test('agent decision context still surfaces nearby power-ups as the top setup fo
     tick: 10,
     bounds: state.bounds,
     directorNote: null,
+    lastDecision: null,
     game: state.game,
   };
 
   const decision = buildDecisionContext(perception);
 
-  assert.equal(decision.options[0]?.label, 'go get the ice cube');
-  assert.equal(decision.options.some((option) => option.label === 'chase Carrier'), true);
+  assert.equal(decision.options[0]?.label, 'chase Carrier with the banana');
+  assert.equal(decision.options.some((option) => option.label === 'go get the ice cube'), true);
+  assert.match(decision.prompt, /detour only for a close power-up that creates a faster stop/);
 });
 
 test('agent decision context allows tactical sabotage only against the immediate loose-banana threat', () => {
@@ -1082,6 +1139,7 @@ test('agent decision context allows tactical sabotage only against the immediate
     tick: 10,
     bounds: state.bounds,
     directorNote: null,
+    lastDecision: null,
     game: state.game,
   };
 
@@ -1233,6 +1291,112 @@ test('stale go_to_object goals are cleared after the reevaluation cap', async ()
     assert.equal(runner.goal, null);
     assert.equal(runner.intent, null);
     assert.equal(runner.status, 'reconsidering the route');
+  } finally {
+    await runtime.dispose();
+  }
+});
+
+test('stale movement goals are passed back as last-decision steering context', async () => {
+  let seenLastDecision: string | null = null;
+  const director = new DirectorRuntime(createOutputEngine('drop'), DIRECTOR_CONFIG);
+  const runtime = new SimulationRuntime(director, {
+    game: {
+      title: 'Banana Dash',
+      bananaObjectId: 'banana',
+      goalObjectId: 'home',
+      respawnRules: [{ objectId: 'banana', delayTicks: 1, spawnPoints: [{ x: -4, z: -4 }] }],
+    },
+    maxMoveTicksBeforeReevaluation: 3,
+  });
+
+  try {
+    const internals = runtime as unknown as MutableRuntimeInternals & { simulationAgents: Map<string, StubChooser> };
+    internals.simulationAgents.set('runner', {
+      async query(perception) {
+        seenLastDecision = perception.lastDecision;
+        return { goal: null, status: 'aborted', rawText: '' };
+      },
+    });
+    internals.state.tick = 2;
+    internals.state.agents.push(
+      createAgent('runner', 'Runner', { x: -3, z: 0 }, {
+        speed: 0,
+        status: 'heading to ice',
+        goal: { kind: 'go_to_object', objectId: 'ice-power-up', label: 'go get the ice cube' },
+        intent: { kind: 'go_to_object', objectId: 'ice-power-up', emotion: 'alert' },
+        intentIssuedAtTick: 0,
+      })
+    );
+    internals.state.objects.push(
+      createObject('banana', 'banana', { x: 0, z: 0 }, {
+        contested: true,
+        affordances: [{ kind: 'pick_up', label: 'grab banana' }],
+      }),
+      createObject('ice-power-up', 'ice_cube', { x: 4, z: 0 }, {
+        label: 'ice cube',
+        contested: true,
+        affordances: [{ kind: 'pick_up', label: 'grab ice cube' }],
+      }),
+      createObject('home', 'goal', { x: 5, z: 5 })
+    );
+
+    await runtime.step(0.1);
+    await runtime.waitForIdle();
+
+    assert.equal(seenLastDecision, 'go get the ice cube');
+  } finally {
+    await runtime.dispose();
+  }
+});
+
+test('arriving at a pickup target completes the selected pickup action', async () => {
+  const director = new DirectorRuntime(createOutputEngine('drop'), DIRECTOR_CONFIG);
+  const runtime = new SimulationRuntime(director, {
+    game: {
+      title: 'Banana Dash',
+      bananaObjectId: 'banana',
+      goalObjectId: 'home',
+      respawnRules: [{ objectId: 'banana', delayTicks: 1, spawnPoints: [{ x: -4, z: -4 }] }],
+    },
+    maxMoveTicksBeforeReevaluation: 10,
+  });
+
+  try {
+    const internals = runtime as unknown as MutableRuntimeInternals;
+    internals.state.agents.push(
+      createAgent('runner', 'Runner', { x: 0, z: 0 }, {
+        speed: 0,
+        status: 'heading to bat',
+        goal: { kind: 'go_to_object', objectId: 'bat', label: 'go get the baseball bat' },
+        intent: { kind: 'go_to_object', objectId: 'bat', emotion: 'alert' },
+        intentIssuedAtTick: 0,
+      })
+    );
+    internals.state.objects.push(
+      createObject('banana', 'banana', { x: 4, z: 0 }, {
+        contested: true,
+        affordances: [{ kind: 'pick_up', label: 'grab banana' }],
+      }),
+      createObject('bat', 'bat', { x: 0.2, z: 0 }, {
+        label: 'baseball bat',
+        contested: true,
+        affordances: [{ kind: 'pick_up', label: 'grab baseball bat' }],
+      }),
+      createObject('home', 'goal', { x: 5, z: 5 })
+    );
+
+    await runtime.step(0.1);
+
+    const runner = runtime.getSnapshot().agents.find((agent) => agent.id === 'runner');
+    assert.ok(runner);
+    assert.deepEqual(runner.goal, {
+      kind: 'object_action',
+      objectId: 'bat',
+      affordance: { kind: 'pick_up', label: 'grab baseball bat' },
+      label: 'grab baseball bat',
+    });
+    assert.deepEqual(runner.intent, { kind: 'pick_up', objectId: 'bat', emotion: 'happy' });
+    assert.equal(runner.status, 'grab baseball bat');
   } finally {
     await runtime.dispose();
   }

--- a/apps/simulation/src/runtime/decision-context.ts
+++ b/apps/simulation/src/runtime/decision-context.ts
@@ -23,6 +23,9 @@ export function buildDecisionContext(perception: AgentPerception): DecisionConte
 
   lines.push(`Tick ${perception.tick}. Banana Dash score: ${formatScore(perception)}.`);
   lines.push(`You are ${describeSelfState(perception)}.`);
+  if (perception.lastDecision) {
+    lines.push(`Heavily consider your last decision: ${perception.lastDecision}. Stay with it if it still makes sense, but change course if the banana or carrier situation is clearly better.`);
+  }
   if (perception.directorNote) {
     lines.push(`Director says: ${perception.directorNote}`);
   }
@@ -121,7 +124,7 @@ function addNonCarrierOptions(
           : `${carrier.name} is already in contact range. Prioritize bumping to knock the banana loose.`);
       }
     } else if (shouldPrioritizeCarrier) {
-      lines.push(`The banana is already claimed, so weigh direct pressure on ${carrier.name} against any nearby power-up that would create a cleaner interception.`);
+      lines.push(`The banana is already claimed, so direct pressure on ${carrier.name} is the default; detour only for a close power-up that creates a faster stop.`);
     }
 
     if (perception.self.powerUp?.kind === 'ice_cube' && carrier.distance <= ICE_THROW_RADIUS && !sabotageCoolingDown) {
@@ -335,13 +338,13 @@ function scorePowerUpOption(
   shouldPrioritizeCarrier: boolean,
   powerUpBias: number
 ): number {
-  const distanceBonus = distance == null ? 0 : Math.max(0, 12 - distance * 3);
-  const base = shouldPrioritizeCarrier ? 82 : 88;
+  const distanceBonus = distance == null ? 0 : Math.max(0, 8 - distance * 2);
+  const base = shouldPrioritizeCarrier ? 80 : 78;
   if (objectId.includes('bat')) {
     return base + powerUpBias + distanceBonus;
   }
   if (objectId.includes('ice')) {
-    return base + powerUpBias + distanceBonus + 2;
+    return base + powerUpBias + distanceBonus + 1;
   }
   return base + distanceBonus;
 }
@@ -397,13 +400,13 @@ function distanceBetweenDirections(
 function powerUpBiasForArchetype(archetype: string): number {
   switch (archetype) {
     case 'mira':
-      return 12;
+      return 4;
     case 'beck':
-      return 8;
+      return 3;
     case 'sol':
-      return 5;
+      return 2;
     case 'aria':
-      return 1;
+      return 0;
     default:
       return 0;
   }

--- a/apps/simulation/src/runtime/sensing.ts
+++ b/apps/simulation/src/runtime/sensing.ts
@@ -23,7 +23,8 @@ export function buildPerception(
   bounds: WorldBounds,
   directorNote: string | null,
   game: SimulationGameState,
-  options: SensingOptions = {}
+  options: SensingOptions = {},
+  lastDecision: string | null = null
 ): AgentPerception {
   const agentRadius = options.agentSightRadius ?? 8;
   const objectRadius = options.objectSightRadius ?? 8;
@@ -81,7 +82,7 @@ export function buildPerception(
   nearbyObjects.sort((a, b) => compareByPriority(a.distance, b.distance, mustSeeObjectIds.has(a.id), mustSeeObjectIds.has(b.id)));
   trimToVisibleCount(nearbyObjects, maxNeighbours, (entry) => mustSeeObjectIds.has(entry.id));
 
-  return { self, nearbyAgents, nearbyObjects, tick, bounds, directorNote, game };
+  return { self, nearbyAgents, nearbyObjects, tick, bounds, directorNote, lastDecision, game };
 }
 
 function compareByPriority(aDistance: number, bDistance: number, aPinned: boolean, bPinned: boolean): number {

--- a/apps/simulation/src/runtime/simulation-runtime.ts
+++ b/apps/simulation/src/runtime/simulation-runtime.ts
@@ -97,6 +97,7 @@ export class SimulationRuntime {
   private readonly maxMoveTicksBeforeReevaluation: number;
   private readonly activeControllers: Set<AbortController> = new Set();
   private readonly recentNarrationEvents: NarrationEventSummary[] = [];
+  private readonly lastDecisionByAgentId: Map<string, string> = new Map();
   private readonly movementSubstepSeconds = 0.15;
 
   private disposed = false;
@@ -219,6 +220,7 @@ export class SimulationRuntime {
 
   public removeAgent(agentId: string): void {
     this.simulationAgents.delete(agentId);
+    this.lastDecisionByAgentId.delete(agentId);
     this.state.agents = this.state.agents.filter((a) => a.id !== agentId);
     delete this.state.game.score.deliveries[agentId];
     delete this.state.game.score.forcedDrops[agentId];
@@ -431,7 +433,9 @@ export class SimulationRuntime {
       this.state.tick,
       this.state.bounds,
       this.state.directorNote,
-      cloneGame(this.state.game)
+      cloneGame(this.state.game),
+      {},
+      this.lastDecisionByAgentId.get(agentState.id) ?? null
     );
 
     const controller = new AbortController();
@@ -468,6 +472,7 @@ export class SimulationRuntime {
       }
       const goal = this.coerceCloseRangeGoal(current, result.goal);
       current.goal = goal;
+      this.lastDecisionByAgentId.set(current.id, goal.label);
       const intent = this.mapGoalToIntent(goal);
       current.intent = intent;
       current.intentIssuedAtTick = this.state.tick;
@@ -699,6 +704,9 @@ export class SimulationRuntime {
   }
 
   private clearAgentForReevaluation(agent: SimulationAgentState, status: string): void {
+    if (agent.goal) {
+      this.lastDecisionByAgentId.set(agent.id, agent.goal.label);
+    }
     agent.goal = null;
     agent.intent = null;
     agent.status = status;
@@ -725,6 +733,9 @@ export class SimulationRuntime {
         continue;
       }
       if (arrived.has(agent.id)) {
+        if (this.completeArrivedPickupGoal(agent)) {
+          continue;
+        }
         if (agent.goal.kind === 'go_to_object' || agent.goal.kind === 'go_to_agent') {
           agent.goal = null;
           agent.intent = null;
@@ -736,6 +747,25 @@ export class SimulationRuntime {
         agent.intent = null;
       }
     }
+  }
+
+  private completeArrivedPickupGoal(agent: SimulationAgentState): boolean {
+    if (agent.goal?.kind !== 'go_to_object') return false;
+    const object = this.state.objects.find((entry) => entry.id === agent.goal?.objectId);
+    const affordance = object?.affordances.find((entry) => entry.kind === 'pick_up');
+    if (!object || !object.active || object.heldBy || !affordance) return false;
+    const label = affordance.label;
+    agent.goal = {
+      kind: 'object_action',
+      objectId: object.id,
+      affordance: { ...affordance, label },
+      label,
+    };
+    agent.intent = { kind: 'pick_up', objectId: object.id, emotion: inferEmotionFromGoal(agent.goal) };
+    agent.intentIssuedAtTick = this.state.tick;
+    agent.status = label;
+    this.lastDecisionByAgentId.set(agent.id, label);
+    return true;
   }
 
   private isGoalInvalid(agent: SimulationAgentState): boolean {

--- a/apps/simulation/src/runtime/types.ts
+++ b/apps/simulation/src/runtime/types.ts
@@ -177,6 +177,7 @@ export interface AgentPerception {
   readonly tick: number;
   readonly bounds: WorldBounds;
   readonly directorNote: string | null;
+  readonly lastDecision: string | null;
   readonly game: SimulationGameState;
 }
 


### PR DESCRIPTION
This pull request introduces significant improvements to the agent decision-making system in the Banana Dash simulation. The main enhancement is the addition of "last decision" context: agents now remember and consider their previous decisions when making new ones, leading to more consistent and context-aware behavior. The decision logic and scoring for power-up options have also been refined to prioritize direct banana plays more heavily, and the character archetype descriptions have been updated for greater clarity and alignment with these new priorities. Several new and updated tests ensure these behaviors work as intended.

**Agent Decision Context and Memory:**

* Agents now track and utilize their last decision when building their decision context, encouraging them to stick with a previous plan unless the situation changes significantly. This is reflected in both the runtime (`SimulationRuntime`) and the perception-building logic. [[1]](diffhunk://#diff-a09ef2d9cb20d07c4636fc4278a3bc0bd3ddac17a8f3892cd445e9c5e5155835R26-R28) [[2]](diffhunk://#diff-8360866d3900dd2c4bf99ec217df7a8a667b6fbb5c2c01212f50b560463c1f40L26-R27) [[3]](diffhunk://#diff-8360866d3900dd2c4bf99ec217df7a8a667b6fbb5c2c01212f50b560463c1f40L84-R85) [[4]](diffhunk://#diff-d3dce99a9d43f6f0d305b4a04f1806e92278d9480acbffc56705315a94f8fcb8R100) [[5]](diffhunk://#diff-d3dce99a9d43f6f0d305b4a04f1806e92278d9480acbffc56705315a94f8fcb8L434-R438) [[6]](diffhunk://#diff-d3dce99a9d43f6f0d305b4a04f1806e92278d9480acbffc56705315a94f8fcb8R475) [[7]](diffhunk://#diff-d3dce99a9d43f6f0d305b4a04f1806e92278d9480acbffc56705315a94f8fcb8R707-R709)
* When agents are removed or reevaluated, their last decision is properly cleared or updated to maintain consistency. [[1]](diffhunk://#diff-d3dce99a9d43f6f0d305b4a04f1806e92278d9480acbffc56705315a94f8fcb8R223) [[2]](diffhunk://#diff-d3dce99a9d43f6f0d305b4a04f1806e92278d9480acbffc56705315a94f8fcb8R707-R709)

**Decision-Making and Prioritization Logic:**

* The decision prompt and option ranking now more strongly favor direct pressure on the banana carrier and discourage detours for power-ups unless they provide a clear advantage. [[1]](diffhunk://#diff-a09ef2d9cb20d07c4636fc4278a3bc0bd3ddac17a8f3892cd445e9c5e5155835L124-R127) [[2]](diffhunk://#diff-a09ef2d9cb20d07c4636fc4278a3bc0bd3ddac17a8f3892cd445e9c5e5155835L338-R347)
* Power-up scoring and archetype biases have been adjusted to further deprioritize power-up detours for all archetypes, making agents more focused on the banana play. [[1]](diffhunk://#diff-a09ef2d9cb20d07c4636fc4278a3bc0bd3ddac17a8f3892cd445e9c5e5155835L338-R347) [[2]](diffhunk://#diff-a09ef2d9cb20d07c4636fc4278a3bc0bd3ddac17a8f3892cd445e9c5e5155835L400-R409)

**Character Archetype Updates:**

* The behavior summaries, descriptions, and notes for all four main characters (`aria`, `beck`, `mira`, `sol`) have been rewritten to clarify their priorities and discourage unnecessary side plays or power-up detours. [[1]](diffhunk://#diff-e36724b5d74fc65926a4a211254dea5bbd1c4fe370f71e7198c3d3dc00cbf4edL5-R13) [[2]](diffhunk://#diff-4d0b0f83bae67f6c1f73391f7f6783f52583ea2e97b7cea67ece184a958c5a55L5-R13) [[3]](diffhunk://#diff-9f03f85c9bdc603e18c15b8d0eb345b0de91f43ba3ee0d79ce15ef38f8b0f05eL5-R13) [[4]](diffhunk://#diff-bc0c410d0660b1d55c6652aa3917556d8b93468f1331e93ef02dd2d0c6d2e107L5-R13)

**Testing Enhancements:**

* New and updated tests verify that last-decision context is included in perception, that agents maintain or change course appropriately, and that power-up prioritization is working as intended. [[1]](diffhunk://#diff-a4efad1ab9f38282e8622bb320ea64ff0e2bc4a8c037cba951be8a4a8f50a44aR827) [[2]](diffhunk://#diff-a4efad1ab9f38282e8622bb320ea64ff0e2bc4a8c037cba951be8a4a8f50a44aR919-R984) [[3]](diffhunk://#diff-a4efad1ab9f38282e8622bb320ea64ff0e2bc4a8c037cba951be8a4a8f50a44aR1058-R1066) [[4]](diffhunk://#diff-a4efad1ab9f38282e8622bb320ea64ff0e2bc4a8c037cba951be8a4a8f50a44aR1142) [[5]](diffhunk://#diff-a4efad1ab9f38282e8622bb320ea64ff0e2bc4a8c037cba951be8a4a8f50a44aR1299-R1404)

**Simulation Behavior Improvements:**

* Agents now complete pickup actions upon arrival and pass back stale movement goals as last-decision context for better reevaluation and more realistic behavior. [[1]](diffhunk://#diff-a4efad1ab9f38282e8622bb320ea64ff0e2bc4a8c037cba951be8a4a8f50a44aR1299-R1404) [[2]](diffhunk://#diff-d3dce99a9d43f6f0d305b4a04f1806e92278d9480acbffc56705315a94f8fcb8R736-R738)

These changes collectively make agent behavior more focused, consistent, and aligned with their intended archetypes and the core objective of the game.