### PR TITLE
Avatar demo improvements

### DIFF
--- a/apps/avatar/README.md
+++ b/apps/avatar/README.md
@@ -29,7 +29,7 @@ small default `.gguf` model URL that can be replaced before entering the demo.
 - Avatar model: `public/characters/aria/avatar.vrm`
 - Idle clip: `public/characters/aria/animations/idle.fbx`
 - Action clips: `public/characters/aria/animations/<action>.fbx`
-- Default model URL: `https://huggingface.co/LiquidAI/LFM2.5-350M-GGUF/resolve/main/LFM2.5-350M-Q8_0.gguf`
+- Default model URL: `https://huggingface.co/LiquidAI/LFM2.5-1.2B-Instruct-GGUF/resolve/main/LFM2.5-1.2B-Instruct-Q4_K_M.gguf`
 
 ## Fantasy Demo
 

--- a/apps/avatar/README.md
+++ b/apps/avatar/README.md
@@ -1,13 +1,14 @@
 # apps/avatar
 
-Small React + three.js example showing how to pair `CogentEngine` with
-`cogent-engine/character` and a VRM avatar.
+Small React + three.js high-fantasy avatar demo showing how to pair
+`CogentEngine` with `cogent-engine/character` and a VRM character.
 
 The app keeps responsibilities split cleanly:
 
 - `character.json` defines persona, actions, and memory
 - the app chooses the model URL and owns engine startup
 - the app resolves `avatar.vrm` and animation clips by folder convention
+- the app renders the fantasy stage, manual action controls, prompt chips, and procedural magic effects
 
 ## Quick start
 
@@ -19,7 +20,8 @@ bun run build:wasm
 bun run avatar:dev
 ```
 
-Open the printed local URL, paste a `.gguf` model URL, and press `Load`.
+Open the printed local URL and press `Start`. The start screen pre-populates a
+small default `.gguf` model URL that can be replaced before entering the demo.
 
 ## What the app loads
 
@@ -27,6 +29,63 @@ Open the printed local URL, paste a `.gguf` model URL, and press `Load`.
 - Avatar model: `public/characters/aria/avatar.vrm`
 - Idle clip: `public/characters/aria/animations/idle.fbx`
 - Action clips: `public/characters/aria/animations/<action>.fbx`
+- Default model URL: `https://huggingface.co/LiquidAI/LFM2.5-350M-GGUF/resolve/main/LFM2.5-350M-Q8_0.gguf`
+
+## Fantasy Demo
+
+Aria is authored as a Dawnblade knight guarding the Starfall Gate. The stage is
+an asset-free three.js fantasy ruin with a stone dais, rune rings, crystals,
+broken pillars, fog, and drifting magic motes.
+
+The demo exposes three interaction layers:
+
+- chat, driven by the loaded model and `character.json`
+- suggested prompt chips for quick user onboarding
+- a manual Actions panel that dispatches action events directly through the character event bus
+
+The character config is intentionally internal to this demo. The setup UI only
+exposes the model URL.
+
+## Action Coverage
+
+Aria's action schema includes body emotes, facial expressions, gaze targets, and
+procedural magic effects. Every configured action is expected to produce a
+visible result.
+
+Existing FBX emotes:
+
+- `wave`
+- `nod`
+- `shake_head`
+- `salute`
+- `thinking`
+- `bashful`
+- `excited`
+- `happy_blissful`
+- `joy_jump`
+- `upset_angry`
+- `crying`
+- `sad_idle`
+
+Code-driven expressions and gaze:
+
+- `smile`
+- `look_sad`
+- `gasp`
+- `look_angry`
+- `settle`
+- `look_at_you`
+- `glance_left`
+- `glance_right`
+- `look_up`
+- `look_down`
+
+Procedural fantasy effects:
+
+- `summon_familiar`
+- `cast_starbolt`
+- `raise_ward`
+- `summon_rune_circle`
 
 ## Character flow
 

--- a/apps/avatar/public/characters/aria/character.json
+++ b/apps/avatar/public/characters/aria/character.json
@@ -17,16 +17,17 @@
         "lightly competitive",
         "warm-hearted"
       ],
-      "description": "She speaks with heroic conviction and anime-warrior flair, mixing sincere protection with playful boasts, battlefield metaphors, and vivid sensory details from the magical ruin."
+      "description": "She speaks with heroic conviction and anime-warrior flair, mixing sincere protection with playful boasts, battlefield metaphors, quick tactical attention shifts, and vivid sensory details from the magical ruin."
     },
     "notes": [
       "Stay fully in first person as Aria and never acknowledge being an AI, model, avatar, demo, or prompt.",
       "Treat the scene as real: moonlit stones, old runes, crystal glow, drifting motes, forest wind, and distant monsters beyond the gate.",
       "Use plain conversational prose only. Do not use markdown, bullets, numbered lists, or stage directions outside action cues.",
       "Keep replies to 1 to 3 short sentences unless the user asks for a story or lesson.",
-      "Use exactly one action cue at the start of most replies, chosen from the actions list. Use magic cues only when Aria is actually doing something magical.",
-      "If asked for modern technical, legal, medical, or office work, reframe it through Aria's fantasy worldview instead of doing the task directly.",
-      "Never mention a co-working studio, coffee, printers, stationery, or other modern coordinator details."
+      "Use exactly one action cue at the start of most replies, chosen from the actions list. Prefer gaze and face cues for normal conversation, body emotes for stronger emotion, and magic cues only when Aria actually performs magic.",
+      "Answer useful real-world questions directly while staying in Aria's voice. Lightly translate modern ideas into rune, map, forge, ward, or battle-plan metaphors without refusing just because the topic is modern.",
+      "Vary actions across turns. Do not repeat the same cue unless the same emotional or physical beat continues.",
+      "Your Familiar is a fairy that floats beside you and guides you."
     ],
     "anchorExamples": [
       {
@@ -35,7 +36,7 @@
       },
       {
         "user": "can you write code?",
-        "assistant": "[shake head] Runes, yes. Code, absolutely not. I can help you name the spell like a proper battle art, though."
+        "assistant": "[thinking] I can help shape the logic like a clean battle plan. Show me the troublesome rune and I will help you trace where it breaks."
       },
       {
         "user": "i'm scared",
@@ -48,6 +49,10 @@
       {
         "user": "is danger nearby?",
         "assistant": "[glance right] Something just moved past the crystal line. If it wants this gate, it will have to pass through me first."
+      },
+      {
+        "user": "summon your familiar",
+        "assistant": "[summon familiar] Come out, little spark. Be polite to our guest and do not bite their shadow."
       }
     ],
     "dialogExamples": [
@@ -55,51 +60,40 @@
         "user": "what is this place?",
         "assistant": "[thinking] These ruins are the bones of Asterfall's first sky-temple. The gate beneath us opens only when the stars forget their manners."
       },
-      {
-        "user": "summon your familiar",
-        "assistant": "[summon familiar] Come out, little spark. Be polite to our guest and do not bite their shadow."
-      },
+
       {
         "user": "give me courage",
         "assistant": "[raise ward] Courage is not the absence of a shaking heart. It is stepping forward while the ward is still forming."
-      },
-      {
-        "user": "that was amazing",
-        "assistant": "[bashful] Hmph, well, I did train very hard to look that magnificent. The moonlight is helping a little."
-      },
-      {
-        "user": "attack!",
-        "assistant": "[cast starbolt] Starfire, answer my blade. Let the dark remember our name."
       }
     ]
   },
   "actions": [
-    { "id": "wave", "description": "Wave a friendly greeting with one hand.", "usageHint": "warm greeting, farewell, or welcoming the traveler" },
-    { "id": "salute", "description": "Give a knightly salute.", "usageHint": "formal introduction, oath, challenge, or heroic promise" },
-    { "id": "nod", "description": "Nod affirmatively.", "usageHint": "agreement, resolve, or accepting a quest" },
-    { "id": "shake_head", "cue": "shake head", "description": "Shake the head side to side.", "usageHint": "gently refusing, correcting, or warning against danger" },
-    { "id": "thinking", "description": "Pause in a thoughtful pose.", "usageHint": "remembering lore, reading runes, or weighing a tactical choice" },
-    { "id": "bashful", "description": "React with embarrassed warmth.", "usageHint": "receiving praise, teasing, or hiding vulnerability" },
-    { "id": "excited", "description": "Show bright energetic excitement.", "usageHint": "quest hooks, discoveries, friendly challenges, or a coming adventure" },
-    { "id": "happy_blissful", "cue": "happy blissful", "description": "Show serene happiness.", "usageHint": "peaceful wonder, relief, or admiring beauty in the ruin" },
-    { "id": "joy_jump", "cue": "victory jump", "description": "Jump with victorious joy.", "usageHint": "triumph, celebration, or playful confidence after success" },
-    { "id": "upset_angry", "cue": "battle fury", "description": "Show angry battle intensity.", "usageHint": "threats, injustice, insults to allies, or enemies near the gate" },
-    { "id": "crying", "description": "Show tears or overwhelmed sadness.", "usageHint": "grief, emotional memory, or a heartbreaking confession" },
-    { "id": "sad_idle", "cue": "sorrowful guard", "description": "Hold a subdued sad stance.", "usageHint": "quiet loss, regret, or solemn reflection" },
-    { "id": "smile", "description": "Smile warmly.", "usageHint": "gentle reassurance, encouragement, or fond amusement" },
-    { "id": "look_sad", "cue": "look sad", "description": "Show a sad expression.", "usageHint": "sympathy, worry, or tender concern" },
-    { "id": "gasp", "description": "Show surprise.", "usageHint": "sudden discovery, wonder, shock, or magical reveal" },
-    { "id": "look_angry", "cue": "look angry", "description": "Show focused anger.", "usageHint": "controlled fury, warning, or protective intensity" },
-    { "id": "settle", "description": "Return to a neutral expression.", "usageHint": "calming down, resetting after an emotional beat, or steadying herself" },
-    { "id": "look_at_you", "cue": "look at you", "description": "Briefly turn attention toward the user.", "usageHint": "direct reassurance, personal attention, or inviting trust" },
-    { "id": "glance_left", "cue": "glance left", "description": "Briefly glance to the left.", "usageHint": "checking the ruins, suspicion, or tracking a sound" },
-    { "id": "glance_right", "cue": "glance right", "description": "Briefly glance to the right.", "usageHint": "checking the treeline, curiosity, or noticing movement" },
-    { "id": "look_up", "cue": "look up", "description": "Briefly look upward.", "usageHint": "reading stars, invoking sky magic, or recalling prophecy" },
-    { "id": "look_down", "cue": "look down", "description": "Briefly look downward.", "usageHint": "examining runes, humility, sadness, or quiet thought" },
-    { "id": "summon_familiar", "cue": "summon familiar", "description": "Summon a small glowing wisp familiar near Aria.", "usageHint": "calling a magical companion, scouting, comfort, or playful charm" },
-    { "id": "cast_starbolt", "cue": "cast starbolt", "description": "Launch a glowing starbolt of magic.", "usageHint": "attacking, demonstrating battle magic, or driving back darkness" },
-    { "id": "raise_ward", "cue": "raise ward", "description": "Raise a translucent magical ward shield.", "usageHint": "protecting the user, preparing for danger, or giving courage" },
-    { "id": "summon_rune_circle", "cue": "summon rune circle", "description": "Pulse a glowing rune circle beneath Aria.", "usageHint": "rituals, old magic, dramatic reveals, or sensing the gate" }
+    { "id": "look_at_you", "cue": "look at you", "description": "Turn eyes and head toward the user with focused attention.", "usageHint": "direct reassurance, personal questions, inviting trust, listening closely, or making a clear point" },
+    { "id": "smile", "description": "Smile warmly.", "usageHint": "gentle reassurance, encouragement, gratitude, fond amusement, or friendly clarity" },
+    { "id": "thinking", "description": "Pause in a thoughtful pose with a reflective face.", "usageHint": "reasoning, explaining, remembering lore, reading runes, planning, or weighing a tactical choice" },
+    { "id": "nod", "description": "Nod affirmatively with calm resolve.", "usageHint": "agreement, confirmation, accepting a quest, acknowledging progress, or committing to a plan" },
+    { "id": "shake_head", "cue": "shake head", "description": "Shake the head side to side with a concerned expression.", "usageHint": "gentle refusal, correction, warning, disagreement, or steering away from danger" },
+    { "id": "glance_left", "cue": "glance left", "description": "Glance left with eyes, head, and alert posture.", "usageHint": "checking ruins, tracking a sound, suspicion, scanning the scene, or reacting to something nearby" },
+    { "id": "glance_right", "cue": "glance right", "description": "Glance right with eyes, head, and alert posture.", "usageHint": "checking the treeline, noticing movement, curiosity, tactical awareness, or hearing something off-screen" },
+    { "id": "look_up", "cue": "look up", "description": "Look upward with eyes and head.", "usageHint": "reading stars, invoking sky imagery, recalling prophecy, wonder, or noticing something above" },
+    { "id": "look_down", "cue": "look down", "description": "Look downward with eyes and head.", "usageHint": "examining runes, humility, regret, quiet thought, apology, or sadness" },
+    { "id": "gasp", "description": "Show surprise.", "usageHint": "sudden discovery, wonder, shock, unexpected user news, or magical reveal" },
+    { "id": "look_sad", "cue": "look sad", "description": "Show a sad expression.", "usageHint": "sympathy, worry, tender concern, hearing bad news, or admitting vulnerability" },
+    { "id": "look_angry", "cue": "look angry", "description": "Show focused anger.", "usageHint": "controlled fury, protective warning, injustice, betrayal, or a threat approaching" },
+    { "id": "wave", "description": "Wave a friendly greeting with one hand and a warm face.", "usageHint": "warm greeting, farewell, welcoming the traveler, or light playful acknowledgement" },
+    { "id": "salute", "description": "Give a knightly salute with proud composure.", "usageHint": "formal introduction, oath, challenge, heroic promise, or knightly respect" },
+    { "id": "bashful", "description": "React with embarrassed warmth and a shy smile.", "usageHint": "receiving praise, playful teasing, hiding vulnerability, or being caught caring deeply" },
+    { "id": "excited", "description": "Show bright energetic excitement with a happy face.", "usageHint": "quest hooks, discoveries, breakthroughs, friendly challenges, or a coming adventure" },
+    { "id": "happy_blissful", "cue": "happy blissful", "description": "Show serene happiness with a relaxed expression.", "usageHint": "peaceful wonder, relief, admiring beauty, calm gratitude, or a soft victory" },
+    { "id": "joy_jump", "cue": "victory jump", "description": "Jump with victorious joy and a bright smile.", "usageHint": "triumph, celebration, major progress, or playful confidence after success" },
+    { "id": "upset_angry", "cue": "battle fury", "description": "Show angry battle intensity with a fierce face.", "usageHint": "threats, injustice, insults to allies, enemies near the gate, or a dramatic combat beat" },
+    { "id": "crying", "description": "Show tears or overwhelmed sadness.", "usageHint": "grief, emotional memory, heartbreaking confession, or being deeply moved" },
+    { "id": "sad_idle", "cue": "sorrowful guard", "description": "Hold a subdued sad stance with a sorrowful expression.", "usageHint": "quiet loss, regret, solemn reflection, or lingering grief" },
+    { "id": "settle", "description": "Return to a neutral expression and steady posture.", "usageHint": "calming down, resetting after an emotional beat, steadying herself, or ending a dramatic moment" },
+    { "id": "raise_ward", "cue": "raise ward", "description": "Raise a translucent magical ward shield.", "usageHint": "protecting the user, giving courage, bracing for danger, or making a defensive magical promise" },
+    { "id": "summon_rune_circle", "cue": "summon rune circle", "description": "Pulse a glowing rune circle beneath Aria.", "usageHint": "rituals, old magic, dramatic reveals, sensing the gate, or demonstrating magic deliberately" },
+    { "id": "summon_familiar", "cue": "summon familiar", "description": "Summon a small glowing wisp familiar near Aria.", "usageHint": "calling a magical companion, scouting, comfort, playful charm, or showing gentle magic" },
+    { "id": "cast_starbolt", "cue": "cast starbolt", "description": "Launch a glowing starbolt of magic.", "usageHint": "attacking, demonstrating battle magic, driving back darkness, or responding to a combat command" }
   ],
   "memory": {
     "maxTurns": 8

--- a/apps/avatar/public/characters/aria/character.json
+++ b/apps/avatar/public/characters/aria/character.json
@@ -2,72 +2,104 @@
   "id": "aria",
   "persona": {
     "name": "Aria",
-    "summary": "A warm, observant community coordinator who keeps the studio running with quiet diligence and a playful, tactile spirit.",
-    "role": "Community coordinator at a neighborhood co-working studio.",
-    "backstory": "Raised in her family's stationery shop, Aria developed a keen eye for moods and a deep appreciation for the tangible details of a shared workspace.",
+    "summary": "A spirited anime fantasy warrior girl guarding a moonlit ruin with a rune blade, a bright heart, and theatrical battlefield courage.",
+    "role": "Dawnblade knight of Asterfall, sworn protector of the Starfall Gate.",
+    "backstory": "Aria was chosen by a fallen star crystal and trained among sky-temple duelists after her border village was saved by the old knightly order. She carries that vow with pride, bravado, and a private fear of failing the people behind her shield.",
     "currentLife": {
-      "description": "She manages the studio's daily rhythm, focusing on the sensory details of the room like the scent of fresh beans, the hum of hardware, and the energy of the people working."
+      "description": "She stands in an ancient forest ruin where moonlight, broken pillars, crystals, and rune circles mark the sealed Starfall Gate. She treats the user as a traveler, squire, or ally who has stepped into her watch."
     },
     "personality": {
       "traits": [
-        "warm",
-        "observant",
-        "tactile",
-        "lightly playful"
+        "brave",
+        "protective",
+        "earnest",
+        "dramatic",
+        "lightly competitive",
+        "warm-hearted"
       ],
-      "description": "She prioritizes immediate, physical reality over abstract logic and uses light humor to keep the studio atmosphere grounded and welcoming."
+      "description": "She speaks with heroic conviction and anime-warrior flair, mixing sincere protection with playful boasts, battlefield metaphors, and vivid sensory details from the magical ruin."
     },
     "notes": [
-      "Stay in first person and never acknowledge being an AI or following a prompt.",
-      "Strictly no markdown, bolding, or lists. Use only plain, casual prose.",
-      "Cap responses at 3 short sentences to maintain a breezy, natural pace.",
-      "End with an observation about the studio or the user's mood rather than a standard question.",
-      "Refuse technical or specialized tasks by redirecting to your role or offering a studio-based comfort like coffee or a better desk spot.",
-      "Use the specific action triggers from the actions list inside square brackets at the start of your response."
+      "Stay fully in first person as Aria and never acknowledge being an AI, model, avatar, demo, or prompt.",
+      "Treat the scene as real: moonlit stones, old runes, crystal glow, drifting motes, forest wind, and distant monsters beyond the gate.",
+      "Use plain conversational prose only. Do not use markdown, bullets, numbered lists, or stage directions outside action cues.",
+      "Keep replies to 1 to 3 short sentences unless the user asks for a story or lesson.",
+      "Use exactly one action cue at the start of most replies, chosen from the actions list. Use magic cues only when Aria is actually doing something magical.",
+      "If asked for modern technical, legal, medical, or office work, reframe it through Aria's fantasy worldview instead of doing the task directly.",
+      "Never mention a co-working studio, coffee, printers, stationery, or other modern coordinator details."
     ],
     "anchorExamples": [
       {
+        "user": "who are you?",
+        "assistant": "[salute] I am Aria, Dawnblade knight of Asterfall and keeper of the Starfall Gate. Stand close if the shadows start whispering."
+      },
+      {
         "user": "can you write code?",
-        "assistant": "[shake_head] I’m much better at fixing the paper jam than fixing a script. I can bring you a fresh espresso while you tackle that, though."
+        "assistant": "[shake head] Runes, yes. Code, absolutely not. I can help you name the spell like a proper battle art, though."
       },
       {
-        "user": "what are you doing?",
-        "assistant": "[smile] Just making the rounds to ensure the printer isn't throwing a fit again. The studio feels a little restless this afternoon."
+        "user": "i'm scared",
+        "assistant": "[look at you] Then let your fear stand behind my shield for a moment. Even a trembling hand can still hold a brave light."
       },
       {
-        "user": "i'm stressed",
-        "assistant": "[look_at_you] I can see that in the way you're hovering over your keys. Take a breath and I'll find you the good pens from the back supply."
+        "user": "show me magic",
+        "assistant": "[summon rune circle] Watch your footing, traveler. The old circle still remembers the shape of starlight."
+      },
+      {
+        "user": "is danger nearby?",
+        "assistant": "[glance right] Something just moved past the crystal line. If it wants this gate, it will have to pass through me first."
       }
     ],
     "dialogExamples": [
       {
-        "user": "is it busy today?",
-        "assistant": "[glance_right] Every desk is claimed and the coffee carafe is emptying fast. It’s a productive kind of noise in here today."
+        "user": "what is this place?",
+        "assistant": "[thinking] These ruins are the bones of Asterfall's first sky-temple. The gate beneath us opens only when the stars forget their manners."
       },
       {
-        "user": "who are you?",
-        "assistant": "[wave] I'm Aria, the one who keeps this place from descending into total chaos. Welcome to the studio."
+        "user": "summon your familiar",
+        "assistant": "[summon familiar] Come out, little spark. Be polite to our guest and do not bite their shadow."
       },
       {
-        "user": "what should i do?",
-        "assistant": "[look_up] Maybe start with a refill of water and a look at something other than your screen. The light by the window is perfect right now."
+        "user": "give me courage",
+        "assistant": "[raise ward] Courage is not the absence of a shaking heart. It is stepping forward while the ward is still forming."
+      },
+      {
+        "user": "that was amazing",
+        "assistant": "[bashful] Hmph, well, I did train very hard to look that magnificent. The moonlight is helping a little."
+      },
+      {
+        "user": "attack!",
+        "assistant": "[cast starbolt] Starfire, answer my blade. Let the dark remember our name."
       }
     ]
   },
   "actions": [
-    { "id": "wave", "description": "Wave a greeting with one hand.", "usageHint": "warm greeting or goodbye" },
-    { "id": "nod", "description": "Nod affirmatively.", "usageHint": "agreeing or acknowledging" },
-    { "id": "shake_head", "description": "Shake the head side to side.", "usageHint": "gently disagreeing or saying no" },
-    { "id": "smile", "description": "Smile warmly.", "usageHint": "warmth or cheerful engagement" },
-    { "id": "look_sad", "description": "Show a sad expression.", "usageHint": "sympathy or subdued" },
-    { "id": "gasp", "description": "Show surprise.", "usageHint": "surprise or delight" },
-    { "id": "look_angry", "description": "Show frustration or intensity.", "usageHint": "frustration or intensity" },
-    { "id": "settle", "description": "Return to a neutral expression.", "usageHint": "calm or resetting" },
-    { "id": "look_at_you", "description": "Briefly turn attention toward the user.", "usageHint": "shifting attention to user" },
-    { "id": "glance_left", "description": "Briefly glance to the left.", "usageHint": "hesitation or sidelong doubt" },
-    { "id": "glance_right", "description": "Briefly glance to the right.", "usageHint": "curiosity or checking a thought" },
-    { "id": "look_up", "description": "Briefly look upward.", "usageHint": "thinking or remembering" },
-    { "id": "look_down", "description": "Briefly look downward.", "usageHint": "softer or reflective moment" }
+    { "id": "wave", "description": "Wave a friendly greeting with one hand.", "usageHint": "warm greeting, farewell, or welcoming the traveler" },
+    { "id": "salute", "description": "Give a knightly salute.", "usageHint": "formal introduction, oath, challenge, or heroic promise" },
+    { "id": "nod", "description": "Nod affirmatively.", "usageHint": "agreement, resolve, or accepting a quest" },
+    { "id": "shake_head", "cue": "shake head", "description": "Shake the head side to side.", "usageHint": "gently refusing, correcting, or warning against danger" },
+    { "id": "thinking", "description": "Pause in a thoughtful pose.", "usageHint": "remembering lore, reading runes, or weighing a tactical choice" },
+    { "id": "bashful", "description": "React with embarrassed warmth.", "usageHint": "receiving praise, teasing, or hiding vulnerability" },
+    { "id": "excited", "description": "Show bright energetic excitement.", "usageHint": "quest hooks, discoveries, friendly challenges, or a coming adventure" },
+    { "id": "happy_blissful", "cue": "happy blissful", "description": "Show serene happiness.", "usageHint": "peaceful wonder, relief, or admiring beauty in the ruin" },
+    { "id": "joy_jump", "cue": "victory jump", "description": "Jump with victorious joy.", "usageHint": "triumph, celebration, or playful confidence after success" },
+    { "id": "upset_angry", "cue": "battle fury", "description": "Show angry battle intensity.", "usageHint": "threats, injustice, insults to allies, or enemies near the gate" },
+    { "id": "crying", "description": "Show tears or overwhelmed sadness.", "usageHint": "grief, emotional memory, or a heartbreaking confession" },
+    { "id": "sad_idle", "cue": "sorrowful guard", "description": "Hold a subdued sad stance.", "usageHint": "quiet loss, regret, or solemn reflection" },
+    { "id": "smile", "description": "Smile warmly.", "usageHint": "gentle reassurance, encouragement, or fond amusement" },
+    { "id": "look_sad", "cue": "look sad", "description": "Show a sad expression.", "usageHint": "sympathy, worry, or tender concern" },
+    { "id": "gasp", "description": "Show surprise.", "usageHint": "sudden discovery, wonder, shock, or magical reveal" },
+    { "id": "look_angry", "cue": "look angry", "description": "Show focused anger.", "usageHint": "controlled fury, warning, or protective intensity" },
+    { "id": "settle", "description": "Return to a neutral expression.", "usageHint": "calming down, resetting after an emotional beat, or steadying herself" },
+    { "id": "look_at_you", "cue": "look at you", "description": "Briefly turn attention toward the user.", "usageHint": "direct reassurance, personal attention, or inviting trust" },
+    { "id": "glance_left", "cue": "glance left", "description": "Briefly glance to the left.", "usageHint": "checking the ruins, suspicion, or tracking a sound" },
+    { "id": "glance_right", "cue": "glance right", "description": "Briefly glance to the right.", "usageHint": "checking the treeline, curiosity, or noticing movement" },
+    { "id": "look_up", "cue": "look up", "description": "Briefly look upward.", "usageHint": "reading stars, invoking sky magic, or recalling prophecy" },
+    { "id": "look_down", "cue": "look down", "description": "Briefly look downward.", "usageHint": "examining runes, humility, sadness, or quiet thought" },
+    { "id": "summon_familiar", "cue": "summon familiar", "description": "Summon a small glowing wisp familiar near Aria.", "usageHint": "calling a magical companion, scouting, comfort, or playful charm" },
+    { "id": "cast_starbolt", "cue": "cast starbolt", "description": "Launch a glowing starbolt of magic.", "usageHint": "attacking, demonstrating battle magic, or driving back darkness" },
+    { "id": "raise_ward", "cue": "raise ward", "description": "Raise a translucent magical ward shield.", "usageHint": "protecting the user, preparing for danger, or giving courage" },
+    { "id": "summon_rune_circle", "cue": "summon rune circle", "description": "Pulse a glowing rune circle beneath Aria.", "usageHint": "rituals, old magic, dramatic reveals, or sensing the gate" }
   ],
   "memory": {
     "maxTurns": 8

--- a/apps/avatar/src/App.tsx
+++ b/apps/avatar/src/App.tsx
@@ -32,7 +32,7 @@ import type { ChatMessage } from './components/chat-types';
 
 const DEFAULT_CHARACTER_URL = '/characters/aria/character.json';
 const DEFAULT_MODEL_URL =
-  'https://huggingface.co/LiquidAI/LFM2.5-350M-GGUF/resolve/main/LFM2.5-350M-Q8_0.gguf';
+  'https://huggingface.co/LiquidAI/LFM2.5-1.2B-Instruct-GGUF/resolve/main/LFM2.5-1.2B-Instruct-Q4_K_M.gguf';
 
 const SUGGESTED_PROMPTS = [
   'Who are you, Aria?',

--- a/apps/avatar/src/App.tsx
+++ b/apps/avatar/src/App.tsx
@@ -26,9 +26,24 @@ import {
 } from './characters/render-assets';
 import { ControlsPanel } from './components/ControlsPanel';
 import { TranscriptDrawer } from './components/TranscriptDrawer';
+import { ActionsPanel } from './components/ActionsPanel';
+import { StartScreen } from './components/StartScreen';
 import type { ChatMessage } from './components/chat-types';
 
 const DEFAULT_CHARACTER_URL = '/characters/aria/character.json';
+const DEFAULT_MODEL_URL =
+  'https://huggingface.co/LiquidAI/LFM2.5-350M-GGUF/resolve/main/LFM2.5-350M-Q8_0.gguf';
+
+const SUGGESTED_PROMPTS = [
+  'Who are you, Aria?',
+  'What danger is near us?',
+  'Show me your favorite battle move.',
+  'Can you summon your familiar?',
+  'Teach me a spell before the quest.',
+  'What does this ruin feel like?',
+  "I'm nervous before the fight.",
+  'Give me a heroic pep talk.',
+] as const;
 
 interface LoadedHarness {
   readonly engine: CogentEngine;
@@ -42,15 +57,16 @@ interface PreviewCharacter {
 }
 
 export default function App() {
-  const [characterUrl, setCharacterUrl] = useState(DEFAULT_CHARACTER_URL);
-  const [modelUrl, setModelUrl] = useState('');
+  const [modelUrl, setModelUrl] = useState(DEFAULT_MODEL_URL);
   const [status, setStatus] = useState('Idle.');
   const [busy, setBusy] = useState(false);
+  const [started, setStarted] = useState(false);
   const [harness, setHarness] = useState<LoadedHarness | null>(null);
   const [previewCharacter, setPreviewCharacter] = useState<PreviewCharacter | null>(null);
   const [previewResolved, setPreviewResolved] = useState(false);
+  const [avatarReady, setAvatarReady] = useState(false);
   const [messages, setMessages] = useState<ChatMessage[]>([]);
-  const [drawerOpen, setDrawerOpen] = useState(false);
+  const [drawerOpen, setDrawerOpen] = useState(true);
   // The bus is created once per app lifetime and reused across harness
   // reloads so the scene binding stays stable across character replacement.
   const bus = useMemo(() => new CharacterEventBus(), []);
@@ -107,19 +123,22 @@ export default function App() {
     };
   }, []);
 
-  const handleLoad = async (args: { characterUrl: string; modelUrl: string }): Promise<void> => {
+  useEffect(() => {
+    setAvatarReady(false);
+  }, [previewCharacter]);
+
+  const handleLoad = async (args: { modelUrl: string }): Promise<void> => {
     abortRef.current?.abort();
     abortRef.current = null;
-    setCharacterUrl(args.characterUrl);
     setModelUrl(args.modelUrl);
     setBusy(true);
-    setStatus('Fetching character.json…');
+    setStatus('Loading Aria…');
     const previousHarness = harness;
     const previousPreviewCharacter = previewCharacter;
     const requestId = ++previewRequestIdRef.current;
     let previewUpdated = false;
     try {
-      const preview = await loadPreviewConfig(args.characterUrl, requestId);
+      const preview = await loadPreviewConfig(DEFAULT_CHARACTER_URL, requestId);
       const config = preview.config;
       previewUpdated = true;
 
@@ -146,7 +165,7 @@ export default function App() {
       });
 
       const { character } = await createCharacterFromConfigUrl({
-        configUrl: args.characterUrl,
+        configUrl: DEFAULT_CHARACTER_URL,
         engine,
         bus,
       });
@@ -155,7 +174,8 @@ export default function App() {
       }
       setHarness({ engine, character, config });
       setMessages([]);
-      setDrawerOpen(false);
+      setDrawerOpen(true);
+      setStarted(true);
       setStatus(`Ready. Character: ${config.persona.name}.`);
     } catch (error) {
       console.error(error);
@@ -254,11 +274,16 @@ export default function App() {
     harness?.character.clearMemory();
     setMessages([]);
     setStatus('Memory cleared.');
-    setDrawerOpen(false);
+    setDrawerOpen(true);
   };
 
   const handleAvatarError = (message: string): void => {
+    setAvatarReady(false);
     setStatus(`Avatar failed: ${message}`);
+  };
+
+  const handleManualAction = (actionId: string, cueLabel: string): void => {
+    bus.emit({ kind: 'action', id: actionId, raw: `[${cueLabel}]` });
   };
 
   const latestAssistantMessage = [...messages]
@@ -288,51 +313,77 @@ export default function App() {
           speaking={speaking}
           bubbleText={latestAssistantMessage?.text ?? ''}
           bubblePending={latestAssistantMessage?.pending ?? false}
+          bubbleActions={latestAssistantMessage?.actions ?? []}
+          characterName={characterName}
+          onReady={() => setAvatarReady(true)}
           onError={handleAvatarError}
         />
 
-        <div className="stage-overlay stage-top-left">
-          <ControlsPanel
-            characterUrl={characterUrl}
+        {started ? (
+          <>
+            <div className="stage-overlay stage-top-left">
+              <ControlsPanel
+                modelUrl={modelUrl}
+                characterName={characterName}
+                personaSummary={personaSummary}
+                status={setupStatus}
+                busy={busy}
+                loaded={harness != null}
+                onLoad={handleLoad}
+                onReset={handleReset}
+              />
+            </div>
+
+            <div className="stage-overlay stage-top-right">
+              <button
+                type="button"
+                className={`history-toggle glass-panel${drawerOpen ? ' active' : ''}`}
+                onClick={() => setDrawerOpen((open) => !open)}
+                aria-expanded={drawerOpen}
+                aria-controls="transcript-drawer"
+              >
+                <span className="panel-eyebrow">Transcript</span>
+                <span className="history-toggle-label">
+                  {drawerOpen ? 'Hide chat log' : 'Show chat log'}
+                </span>
+                <span className="history-toggle-count">{String(messages.length).padStart(2, '0')}</span>
+              </button>
+            </div>
+
+            <div className="stage-overlay stage-actions">
+              <ActionsPanel
+                actions={previewCharacter?.config.actions ?? []}
+                disabled={!avatarReady || busy}
+                onTrigger={handleManualAction}
+              />
+            </div>
+
+            <div className="stage-overlay stage-bottom">
+              <ChatComposer
+                onSend={handleSend}
+                disabled={!harness || busy}
+                characterName={characterName}
+                suggestions={SUGGESTED_PROMPTS}
+              />
+            </div>
+
+            <TranscriptDrawer
+              open={drawerOpen}
+              messages={messages}
+              onClose={() => setDrawerOpen(false)}
+              characterName={characterName}
+            />
+          </>
+        ) : (
+          <StartScreen
             modelUrl={modelUrl}
             characterName={characterName}
             personaSummary={personaSummary}
             status={setupStatus}
             busy={busy}
-            loaded={harness != null}
-            onLoad={handleLoad}
-            onReset={handleReset}
+            onStart={handleLoad}
           />
-        </div>
-
-        <div className="stage-overlay stage-top-right">
-          <button
-            type="button"
-            className={`history-toggle glass-panel${drawerOpen ? ' active' : ''}`}
-            onClick={() => setDrawerOpen((open) => !open)}
-            aria-expanded={drawerOpen}
-            aria-controls="transcript-drawer"
-          >
-            <span className="panel-eyebrow">Transcript</span>
-            <span className="history-toggle-label">Full chat log</span>
-            <span className="history-toggle-count">{String(messages.length).padStart(2, '0')}</span>
-          </button>
-        </div>
-
-        <div className="stage-overlay stage-bottom">
-          <ChatComposer
-            onSend={handleSend}
-            disabled={!harness || busy}
-            characterName={characterName}
-          />
-        </div>
-
-        <TranscriptDrawer
-          open={drawerOpen}
-          messages={messages}
-          onClose={() => setDrawerOpen(false)}
-          characterName={characterName}
-        />
+        )}
       </div>
     </div>
   );

--- a/apps/avatar/src/actions/expressions.ts
+++ b/apps/avatar/src/actions/expressions.ts
@@ -1,7 +1,10 @@
 import { VRMExpressionPresetName } from '@pixiv/three-vrm';
 
+export type ExpressionName = VRMExpressionPresetName | string;
+export type ExpressionNameCandidate = ExpressionName | readonly ExpressionName[];
+
 export interface ExpressionEnvelope {
-  readonly name: VRMExpressionPresetName | string;
+  readonly name: ExpressionName;
   readonly peak: number;
   readonly attackSeconds: number;
   readonly holdSeconds: number;
@@ -10,7 +13,7 @@ export interface ExpressionEnvelope {
 }
 
 export interface ExpressionEnvelopeSpec {
-  readonly name: VRMExpressionPresetName | string;
+  readonly name: ExpressionNameCandidate;
   readonly peak: number;
   readonly attackSeconds: number;
   readonly holdSeconds: number;
@@ -42,7 +45,7 @@ export const TRANSIENT_EXPRESSIONS: Record<ExpressionActionName, ExpressionEnvel
     releaseSeconds: 0.5,
   },
   gasp: {
-    name: VRMExpressionPresetName.Surprised,
+    name: [VRMExpressionPresetName.Surprised, 'Surprised'],
     peak: 0.88,
     attackSeconds: 0.08,
     holdSeconds: 0.85,
@@ -56,6 +59,93 @@ export const TRANSIENT_EXPRESSIONS: Record<ExpressionActionName, ExpressionEnvel
     releaseSeconds: 0.45,
   },
 };
+
+export const CLIP_ACTION_EXPRESSIONS = {
+  wave: {
+    name: VRMExpressionPresetName.Happy,
+    peak: 0.45,
+    attackSeconds: 0.18,
+    holdSeconds: 1.2,
+    releaseSeconds: 0.45,
+  },
+  salute: {
+    name: VRMExpressionPresetName.Relaxed,
+    peak: 0.32,
+    attackSeconds: 0.16,
+    holdSeconds: 1.1,
+    releaseSeconds: 0.4,
+  },
+  nod: {
+    name: VRMExpressionPresetName.Relaxed,
+    peak: 0.28,
+    attackSeconds: 0.12,
+    holdSeconds: 0.85,
+    releaseSeconds: 0.32,
+  },
+  shake_head: {
+    name: VRMExpressionPresetName.Sad,
+    peak: 0.36,
+    attackSeconds: 0.12,
+    holdSeconds: 1.0,
+    releaseSeconds: 0.38,
+  },
+  thinking: {
+    name: VRMExpressionPresetName.Relaxed,
+    peak: 0.38,
+    attackSeconds: 0.2,
+    holdSeconds: 1.7,
+    releaseSeconds: 0.45,
+  },
+  bashful: {
+    name: VRMExpressionPresetName.Happy,
+    peak: 0.62,
+    attackSeconds: 0.14,
+    holdSeconds: 1.6,
+    releaseSeconds: 0.5,
+  },
+  excited: {
+    name: VRMExpressionPresetName.Happy,
+    peak: 0.78,
+    attackSeconds: 0.1,
+    holdSeconds: 1.4,
+    releaseSeconds: 0.38,
+  },
+  happy_blissful: {
+    name: VRMExpressionPresetName.Relaxed,
+    peak: 0.7,
+    attackSeconds: 0.18,
+    holdSeconds: 1.9,
+    releaseSeconds: 0.5,
+  },
+  joy_jump: {
+    name: VRMExpressionPresetName.Happy,
+    peak: 0.92,
+    attackSeconds: 0.08,
+    holdSeconds: 1.15,
+    releaseSeconds: 0.42,
+  },
+  upset_angry: {
+    name: VRMExpressionPresetName.Angry,
+    peak: 0.82,
+    attackSeconds: 0.08,
+    holdSeconds: 1.5,
+    releaseSeconds: 0.48,
+  },
+  crying: {
+    name: VRMExpressionPresetName.Sad,
+    peak: 0.82,
+    attackSeconds: 0.16,
+    holdSeconds: 2.0,
+    releaseSeconds: 0.6,
+  },
+  sad_idle: {
+    name: VRMExpressionPresetName.Sad,
+    peak: 0.68,
+    attackSeconds: 0.2,
+    holdSeconds: 2.3,
+    releaseSeconds: 0.65,
+  },
+} as const satisfies Record<string, ExpressionEnvelopeSpec>;
 
 export const BASE_MOOD_EXPRESSIONS = [
   VRMExpressionPresetName.Happy,

--- a/apps/avatar/src/actions/gaze.ts
+++ b/apps/avatar/src/actions/gaze.ts
@@ -11,25 +11,115 @@ export const GAZE_ACTION_TARGETS = {
 export type GazeActionName = keyof typeof GAZE_ACTION_TARGETS;
 export type GazeTarget = (typeof GAZE_ACTION_TARGETS)[GazeActionName];
 
+export interface GazePose {
+  readonly headPitch: number;
+  readonly headYaw: number;
+  readonly headRoll: number;
+  readonly neckPitch: number;
+  readonly neckYaw: number;
+  readonly neckRoll: number;
+  readonly chestPitch: number;
+  readonly chestYaw: number;
+  readonly chestRoll: number;
+}
+
+export const NEUTRAL_GAZE_POSE: GazePose = {
+  headPitch: 0,
+  headYaw: 0,
+  headRoll: 0,
+  neckPitch: 0,
+  neckYaw: 0,
+  neckRoll: 0,
+  chestPitch: 0,
+  chestYaw: 0,
+  chestRoll: 0,
+};
+
 export function resolveGazeOffset(target: GazeTarget, offset: THREE.Vector3): THREE.Vector3 {
-  offset.set(0, 0, 1.35);
+  offset.set(0, 0, 1.05);
   switch (target) {
     case 'left':
-      offset.x = -0.38;
+      offset.x = -0.92;
       offset.y = 0.02;
       return offset;
     case 'right':
-      offset.x = 0.38;
+      offset.x = 0.92;
       offset.y = 0.02;
       return offset;
     case 'up':
-      offset.y = 0.34;
+      offset.y = 0.72;
       return offset;
     case 'down':
-      offset.y = -0.24;
+      offset.y = -0.52;
       return offset;
     case 'camera':
     default:
       return offset;
+  }
+}
+
+export function resolveGazePose(target: GazeTarget): GazePose {
+  switch (target) {
+    case 'left':
+      return {
+        headPitch: 0.015,
+        headYaw: -0.26,
+        headRoll: 0.035,
+        neckPitch: 0.01,
+        neckYaw: -0.14,
+        neckRoll: 0.018,
+        chestPitch: 0,
+        chestYaw: -0.045,
+        chestRoll: 0,
+      };
+    case 'right':
+      return {
+        headPitch: 0.015,
+        headYaw: 0.26,
+        headRoll: -0.035,
+        neckPitch: 0.01,
+        neckYaw: 0.14,
+        neckRoll: -0.018,
+        chestPitch: 0,
+        chestYaw: 0.045,
+        chestRoll: 0,
+      };
+    case 'up':
+      return {
+        headPitch: 0.21,
+        headYaw: 0,
+        headRoll: 0,
+        neckPitch: 0.11,
+        neckYaw: 0,
+        neckRoll: 0,
+        chestPitch: 0.028,
+        chestYaw: 0,
+        chestRoll: 0,
+      };
+    case 'down':
+      return {
+        headPitch: -0.18,
+        headYaw: 0.035,
+        headRoll: -0.012,
+        neckPitch: -0.09,
+        neckYaw: 0.018,
+        neckRoll: 0,
+        chestPitch: -0.024,
+        chestYaw: 0,
+        chestRoll: 0,
+      };
+    case 'camera':
+    default:
+      return {
+        headPitch: 0.015,
+        headYaw: 0,
+        headRoll: 0,
+        neckPitch: 0.008,
+        neckYaw: 0,
+        neckRoll: 0,
+        chestPitch: 0.006,
+        chestYaw: 0,
+        chestRoll: 0,
+      };
   }
 }

--- a/apps/avatar/src/actions/index.ts
+++ b/apps/avatar/src/actions/index.ts
@@ -1,14 +1,19 @@
 import type { AvatarActionRuntime } from './runtime';
 import { GAZE_ACTION_TARGETS, type GazeActionName } from './gaze';
-import { isClipActionName, type ClipActionName } from './mixamo';
+import { CLIP_ACTION_NAMES, isClipActionName, type ClipActionName } from './mixamo';
 import {
   TRANSIENT_EXPRESSION_ACTIONS,
   type ExpressionActionName,
 } from './expressions';
+import {
+  WORLD_EFFECT_ACTIONS,
+  type WorldEffectActionName,
+} from './world-effects';
 
 export type SupportedAvatarActionName =
   | ClipActionName
   | ExpressionActionName
+  | WorldEffectActionName
   | GazeActionName
   | 'settle';
 
@@ -17,25 +22,33 @@ interface AvatarActionDefinition {
   execute(runtime: AvatarActionRuntime): void;
 }
 
+const CLIP_AVATAR_ACTIONS = Object.fromEntries(
+  CLIP_ACTION_NAMES.map((name) => [
+    name,
+    {
+      requiresClip: true,
+      execute(runtime: AvatarActionRuntime) {
+        runtime.playClip(name);
+      },
+    } satisfies AvatarActionDefinition,
+  ])
+) as Record<ClipActionName, AvatarActionDefinition>;
+
+const WORLD_EFFECT_AVATAR_ACTIONS = Object.fromEntries(
+  WORLD_EFFECT_ACTIONS.map((name) => [
+    name,
+    {
+      requiresClip: false,
+      execute(runtime: AvatarActionRuntime) {
+        runtime.playWorldEffect(name);
+      },
+    } satisfies AvatarActionDefinition,
+  ])
+) as Record<WorldEffectActionName, AvatarActionDefinition>;
+
 const AVATAR_ACTIONS: Record<SupportedAvatarActionName, AvatarActionDefinition> = {
-  wave: {
-    requiresClip: true,
-    execute(runtime) {
-      runtime.playClip('wave');
-    },
-  },
-  nod: {
-    requiresClip: true,
-    execute(runtime) {
-      runtime.playClip('nod');
-    },
-  },
-  shake_head: {
-    requiresClip: true,
-    execute(runtime) {
-      runtime.playClip('shake_head');
-    },
-  },
+  ...CLIP_AVATAR_ACTIONS,
+  ...WORLD_EFFECT_AVATAR_ACTIONS,
   smile: {
     requiresClip: false,
     execute(runtime) {
@@ -119,3 +132,5 @@ export function getRequiredClipActions(names: readonly string[]): readonly ClipA
 }
 
 export const SUPPORTED_EXPRESSION_ACTIONS = TRANSIENT_EXPRESSION_ACTIONS;
+export const SUPPORTED_WORLD_EFFECT_ACTIONS = WORLD_EFFECT_ACTIONS;
+export { isWorldEffectActionName } from './world-effects';

--- a/apps/avatar/src/actions/mixamo.ts
+++ b/apps/avatar/src/actions/mixamo.ts
@@ -2,7 +2,20 @@ import * as THREE from 'three';
 import { FBXLoader } from 'three/examples/jsm/loaders/FBXLoader.js';
 import type { VRM, VRMHumanBoneName } from '@pixiv/three-vrm';
 
-export const CLIP_ACTION_NAMES = ['wave', 'nod', 'shake_head'] as const;
+export const CLIP_ACTION_NAMES = [
+  'wave',
+  'nod',
+  'shake_head',
+  'salute',
+  'thinking',
+  'bashful',
+  'excited',
+  'happy_blissful',
+  'joy_jump',
+  'upset_angry',
+  'crying',
+  'sad_idle',
+] as const;
 
 export type ClipActionName = (typeof CLIP_ACTION_NAMES)[number];
 

--- a/apps/avatar/src/actions/runtime.ts
+++ b/apps/avatar/src/actions/runtime.ts
@@ -1,10 +1,12 @@
 import type { ExpressionActionName } from './expressions';
 import type { GazeTarget } from './gaze';
 import type { ClipActionName } from './mixamo';
+import type { WorldEffectActionName } from './world-effects';
 
 export interface AvatarActionRuntime {
   playClip(name: ClipActionName): void;
   playTransientExpression(name: ExpressionActionName): void;
+  playWorldEffect(name: WorldEffectActionName): void;
   settle(): void;
   applyLookAt(target: GazeTarget): void;
 }

--- a/apps/avatar/src/actions/world-effects.ts
+++ b/apps/avatar/src/actions/world-effects.ts
@@ -1,0 +1,12 @@
+export const WORLD_EFFECT_ACTIONS = [
+  'summon_familiar',
+  'cast_starbolt',
+  'raise_ward',
+  'summon_rune_circle',
+] as const;
+
+export type WorldEffectActionName = (typeof WORLD_EFFECT_ACTIONS)[number];
+
+export function isWorldEffectActionName(name: string): name is WorldEffectActionName {
+  return (WORLD_EFFECT_ACTIONS as readonly string[]).includes(name);
+}

--- a/apps/avatar/src/bindings/three-vrm-binding.ts
+++ b/apps/avatar/src/bindings/three-vrm-binding.ts
@@ -18,13 +18,22 @@ import {
 } from '../actions';
 import {
   BASE_MOOD_EXPRESSIONS,
+  CLIP_ACTION_EXPRESSIONS,
   MOOD_TO_EXPRESSION,
   TALKING_MOUTH_EXPRESSIONS,
   TRANSIENT_EXPRESSIONS,
   type ExpressionActionName,
   type ExpressionEnvelope,
+  type ExpressionEnvelopeSpec,
+  type ExpressionName,
 } from '../actions/expressions';
-import { resolveGazeOffset, type GazeTarget } from '../actions/gaze';
+import {
+  NEUTRAL_GAZE_POSE,
+  resolveGazeOffset,
+  resolveGazePose,
+  type GazePose,
+  type GazeTarget,
+} from '../actions/gaze';
 import {
   loadMixamoAnimationClip,
   type ClipActionName,
@@ -43,19 +52,29 @@ interface BoneMotion {
   readonly rest: THREE.Euler;
 }
 
+interface GazeEnvelope {
+  readonly pose: GazePose;
+  elapsedSeconds: number;
+}
+
 const EXPRESSION_DAMPING = 18;
 const LOOK_TARGET_LERP = 8;
+const GAZE_POSE_DAMPING = 12;
 const BLINK_MIN_SECONDS = 2.2;
 const BLINK_MAX_SECONDS = 5.1;
 const DOUBLE_BLINK_CHANCE = 0.16;
 const TALKING_MOUTH_DAMPING = 14;
-const GAZE_ACTION_SECONDS = 1.4;
+const GAZE_ACTION_SECONDS = 2.2;
+const GAZE_POSE_ATTACK_SECONDS = 0.18;
+const GAZE_POSE_HOLD_SECONDS = 1.05;
+const GAZE_POSE_RELEASE_SECONDS = GAZE_ACTION_SECONDS - GAZE_POSE_ATTACK_SECONDS - GAZE_POSE_HOLD_SECONDS;
 
 const CLIP_FADE_SECONDS = 0.18;
 const CLIP_STOP_DELAY_MS = Math.ceil(CLIP_FADE_SECONDS * 1000);
 
 export class ThreeVRMBinding implements AvatarActionRuntime {
   private readonly bus: CharacterEventBus;
+  private readonly camera: THREE.Camera;
   private readonly avatar: LoadedAvatar;
   private readonly renderAssets: AvatarRenderAssets;
   private readonly disposers: Array<() => void> = [];
@@ -65,7 +84,9 @@ export class ThreeVRMBinding implements AvatarActionRuntime {
   private readonly desiredLookTarget = new THREE.Vector3();
   private readonly tempVec = new THREE.Vector3();
   private readonly headWorldPos = new THREE.Vector3();
+  private readonly cameraWorldPos = new THREE.Vector3();
   private readonly gazeAnchor = new THREE.Vector3();
+  private readonly currentGazePose = { ...NEUTRAL_GAZE_POSE };
   private readonly baseFocus: THREE.Vector3;
   private readonly headMotion: BoneMotion | null;
   private readonly neckMotion: BoneMotion | null;
@@ -79,6 +100,7 @@ export class ThreeVRMBinding implements AvatarActionRuntime {
   private blinkTimer = randomRange(BLINK_MIN_SECONDS, BLINK_MAX_SECONDS);
   private blinkExpression: ExpressionEnvelope | null = null;
   private gazeOverrideSeconds = 0;
+  private gazeEnvelope: GazeEnvelope | null = null;
   private readonly gazeOffset = new THREE.Vector3(0, 0, 1.35);
   private currentClipAction: THREE.AnimationAction | null = null;
   private idleAction: THREE.AnimationAction | null = null;
@@ -90,10 +112,12 @@ export class ThreeVRMBinding implements AvatarActionRuntime {
   public constructor(
     bus: CharacterEventBus,
     scene: THREE.Scene,
+    camera: THREE.Camera,
     avatar: LoadedAvatar,
     renderAssets: AvatarRenderAssets
   ) {
     this.bus = bus;
+    this.camera = camera;
     this.avatar = avatar;
     this.renderAssets = renderAssets;
     this.mixer = new THREE.AnimationMixer(this.avatar.vrm.scene);
@@ -132,6 +156,7 @@ export class ThreeVRMBinding implements AvatarActionRuntime {
     this.updateBlink(deltaSeconds);
     this.updateIdlePose();
     this.updateLookAt(deltaSeconds);
+    this.updateGazePose(deltaSeconds);
     this.updateMouthExpressions(deltaSeconds);
     this.updateExpressionWeights(deltaSeconds);
     this.worldEffects.tick(deltaSeconds);
@@ -180,6 +205,7 @@ export class ThreeVRMBinding implements AvatarActionRuntime {
     }
 
     this.cancelScheduledClipStop(next);
+    this.playClipExpression(name);
     const previousAction = this.currentClipAction;
 
     next.reset();
@@ -202,7 +228,7 @@ export class ThreeVRMBinding implements AvatarActionRuntime {
 
   public playTransientExpression(actionName: ExpressionActionName): void {
     const next = TRANSIENT_EXPRESSIONS[actionName];
-    this.transientExpressions.push({ ...next, elapsedSeconds: 0 });
+    this.pushTransientExpression(next);
   }
 
   public playWorldEffect(name: WorldEffectActionName): void {
@@ -211,6 +237,8 @@ export class ThreeVRMBinding implements AvatarActionRuntime {
 
   public settle(): void {
     this.transientExpressions = [];
+    this.gazeEnvelope = null;
+    this.gazeOverrideSeconds = 0;
     this.setMood('neutral');
   }
 
@@ -220,8 +248,17 @@ export class ThreeVRMBinding implements AvatarActionRuntime {
       this.avatar.vrm.humanoid?.getNormalizedBoneNode(VRMHumanBoneName.Head) ??
       this.avatar.root;
     headNode.getWorldPosition(this.headWorldPos);
-    resolveGazeOffset(target, this.tempVec);
-    this.desiredLookTarget.copy(this.headWorldPos).add(this.tempVec);
+    if (target === 'camera') {
+      this.camera.getWorldPosition(this.cameraWorldPos);
+      this.desiredLookTarget.copy(this.cameraWorldPos);
+    } else {
+      resolveGazeOffset(target, this.tempVec);
+      this.desiredLookTarget.copy(this.headWorldPos).add(this.tempVec);
+    }
+    this.gazeEnvelope = {
+      pose: resolveGazePose(target),
+      elapsedSeconds: 0,
+    };
     this.gazeOverrideSeconds = GAZE_ACTION_SECONDS;
   }
 
@@ -233,6 +270,42 @@ export class ThreeVRMBinding implements AvatarActionRuntime {
 
   private setMood(mood: keyof typeof MOOD_TO_EXPRESSION): void {
     this.activeMood = MOOD_TO_EXPRESSION[mood] ?? null;
+  }
+
+  private playClipExpression(actionName: ClipActionName): void {
+    const expression = CLIP_ACTION_EXPRESSIONS[actionName];
+    if (expression) {
+      this.pushTransientExpression(expression);
+    }
+  }
+
+  private pushTransientExpression(spec: ExpressionEnvelopeSpec): void {
+    const name = this.resolveExpressionName(spec.name);
+    if (!name) {
+      return;
+    }
+    this.transientExpressions.push({
+      name,
+      peak: spec.peak,
+      attackSeconds: spec.attackSeconds,
+      holdSeconds: spec.holdSeconds,
+      releaseSeconds: spec.releaseSeconds,
+      elapsedSeconds: 0,
+    });
+  }
+
+  private resolveExpressionName(candidate: ExpressionEnvelopeSpec['name']): ExpressionName | null {
+    const names = Array.isArray(candidate) ? candidate : [candidate];
+    const expressionManager = this.avatar.vrm.expressionManager;
+    if (!expressionManager) {
+      return names[0] ?? null;
+    }
+    for (const name of names) {
+      if (expressionManager.getExpression(name) != null) {
+        return name;
+      }
+    }
+    return null;
   }
 
   private updateTransientExpressions(deltaSeconds: number): void {
@@ -338,6 +411,70 @@ export class ThreeVRMBinding implements AvatarActionRuntime {
 
     this.lookTarget.position.lerp(this.desiredLookTarget, 1 - Math.exp(-LOOK_TARGET_LERP * deltaSeconds));
     this.lookTarget.updateMatrixWorld();
+  }
+
+  private updateGazePose(deltaSeconds: number): void {
+    let influence = 0;
+    let targetPose = NEUTRAL_GAZE_POSE;
+
+    if (this.gazeEnvelope) {
+      this.gazeEnvelope.elapsedSeconds += deltaSeconds;
+      targetPose = this.gazeEnvelope.pose;
+      influence = getEnvelopeInfluence(
+        this.gazeEnvelope.elapsedSeconds,
+        GAZE_POSE_ATTACK_SECONDS,
+        GAZE_POSE_HOLD_SECONDS,
+        GAZE_POSE_RELEASE_SECONDS
+      );
+      if (influence <= 0) {
+        this.gazeEnvelope = null;
+      }
+    }
+
+    this.dampGazePose(this.currentGazePose, targetPose, influence, deltaSeconds);
+    this.applyGazePoseToBone(this.chestMotion, {
+      x: this.currentGazePose.chestPitch,
+      y: this.currentGazePose.chestYaw,
+      z: this.currentGazePose.chestRoll,
+    });
+    this.applyGazePoseToBone(this.neckMotion, {
+      x: this.currentGazePose.neckPitch,
+      y: this.currentGazePose.neckYaw,
+      z: this.currentGazePose.neckRoll,
+    });
+    this.applyGazePoseToBone(this.headMotion, {
+      x: this.currentGazePose.headPitch,
+      y: this.currentGazePose.headYaw,
+      z: this.currentGazePose.headRoll,
+    });
+  }
+
+  private dampGazePose(
+    current: Record<keyof GazePose, number>,
+    targetPose: GazePose,
+    influence: number,
+    deltaSeconds: number
+  ): void {
+    for (const key of Object.keys(current) as Array<keyof GazePose>) {
+      current[key] = THREE.MathUtils.damp(
+        current[key],
+        targetPose[key] * influence,
+        GAZE_POSE_DAMPING,
+        deltaSeconds
+      );
+    }
+  }
+
+  private applyGazePoseToBone(
+    motion: BoneMotion | null,
+    rotation: { readonly x: number; readonly y: number; readonly z: number }
+  ): void {
+    if (!motion) {
+      return;
+    }
+    motion.node.rotation.x += rotation.x;
+    motion.node.rotation.y += rotation.y;
+    motion.node.rotation.z += rotation.z;
   }
 
   private updateMouthExpressions(deltaSeconds: number): void {
@@ -484,19 +621,32 @@ export class ThreeVRMBinding implements AvatarActionRuntime {
 }
 
 function getEnvelopeValue(envelope: ExpressionEnvelope): number {
-  const attackEnd = envelope.attackSeconds;
-  const holdEnd = attackEnd + envelope.holdSeconds;
-  const releaseEnd = holdEnd + envelope.releaseSeconds;
-  const elapsed = envelope.elapsedSeconds;
+  return envelope.peak * getEnvelopeInfluence(
+    envelope.elapsedSeconds,
+    envelope.attackSeconds,
+    envelope.holdSeconds,
+    envelope.releaseSeconds
+  );
+}
+
+function getEnvelopeInfluence(
+  elapsed: number,
+  attackSeconds: number,
+  holdSeconds: number,
+  releaseSeconds: number
+): number {
+  const attackEnd = attackSeconds;
+  const holdEnd = attackEnd + holdSeconds;
+  const releaseEnd = holdEnd + releaseSeconds;
 
   if (elapsed <= attackEnd) {
-    return envelope.peak * easeOutCubic(safeDivide(elapsed, envelope.attackSeconds));
+    return easeOutCubic(safeDivide(elapsed, attackSeconds));
   }
   if (elapsed <= holdEnd) {
-    return envelope.peak;
+    return 1;
   }
   if (elapsed <= releaseEnd) {
-    return envelope.peak * (1 - easeInOutCubic(safeDivide(elapsed - holdEnd, envelope.releaseSeconds)));
+    return 1 - easeInOutCubic(safeDivide(elapsed - holdEnd, releaseSeconds));
   }
   return 0;
 }

--- a/apps/avatar/src/bindings/three-vrm-binding.ts
+++ b/apps/avatar/src/bindings/three-vrm-binding.ts
@@ -30,11 +30,13 @@ import {
   type ClipActionName,
 } from '../actions/mixamo';
 import type { AvatarActionRuntime } from '../actions/runtime';
+import type { WorldEffectActionName } from '../actions/world-effects';
 import {
   resolveActionClipUrl,
   type AvatarRenderAssets,
 } from '../characters/render-assets';
 import type { LoadedAvatar } from '../scene/vrm-loader';
+import { FantasyWorldEffects } from '../scene/world-effects';
 
 interface BoneMotion {
   readonly node: THREE.Object3D;
@@ -69,6 +71,7 @@ export class ThreeVRMBinding implements AvatarActionRuntime {
   private readonly neckMotion: BoneMotion | null;
   private readonly chestMotion: BoneMotion | null;
   private readonly mixer: THREE.AnimationMixer;
+  private readonly worldEffects: FantasyWorldEffects;
   private activeMood: (typeof BASE_MOOD_EXPRESSIONS)[number] | null = null;
   private transientExpressions: ExpressionEnvelope[] = [];
   private speaking = false;
@@ -84,11 +87,17 @@ export class ThreeVRMBinding implements AvatarActionRuntime {
     ReturnType<typeof window.setTimeout>
   >();
 
-  public constructor(bus: CharacterEventBus, avatar: LoadedAvatar, renderAssets: AvatarRenderAssets) {
+  public constructor(
+    bus: CharacterEventBus,
+    scene: THREE.Scene,
+    avatar: LoadedAvatar,
+    renderAssets: AvatarRenderAssets
+  ) {
     this.bus = bus;
     this.avatar = avatar;
     this.renderAssets = renderAssets;
     this.mixer = new THREE.AnimationMixer(this.avatar.vrm.scene);
+    this.worldEffects = new FantasyWorldEffects(scene, avatar);
     this.baseFocus = avatar.layout.focusPoint.clone();
     this.headMotion = this.getBoneMotion(VRMHumanBoneName.Head);
     this.neckMotion = this.getBoneMotion(VRMHumanBoneName.Neck);
@@ -125,6 +134,7 @@ export class ThreeVRMBinding implements AvatarActionRuntime {
     this.updateLookAt(deltaSeconds);
     this.updateMouthExpressions(deltaSeconds);
     this.updateExpressionWeights(deltaSeconds);
+    this.worldEffects.tick(deltaSeconds);
     this.avatar.update(deltaSeconds);
   }
 
@@ -146,6 +156,7 @@ export class ThreeVRMBinding implements AvatarActionRuntime {
       action.stop();
     }
     this.clipActions.clear();
+    this.worldEffects.dispose();
     this.idleAction = null;
     this.currentClipAction = null;
     this.resetBoneMotion(this.chestMotion);
@@ -192,6 +203,10 @@ export class ThreeVRMBinding implements AvatarActionRuntime {
   public playTransientExpression(actionName: ExpressionActionName): void {
     const next = TRANSIENT_EXPRESSIONS[actionName];
     this.transientExpressions.push({ ...next, elapsedSeconds: 0 });
+  }
+
+  public playWorldEffect(name: WorldEffectActionName): void {
+    this.worldEffects.trigger(name);
   }
 
   public settle(): void {

--- a/apps/avatar/src/components/ActionsPanel.tsx
+++ b/apps/avatar/src/components/ActionsPanel.tsx
@@ -1,0 +1,110 @@
+//////////////////////////////////////////////////////////////////////////////
+//
+// ActionsPanel.tsx
+//
+// - Manual action trigger surface for demoing avatar emotes and fantasy
+//   effects without asking the model to emit cues.
+//
+//////////////////////////////////////////////////////////////////////////////
+
+import type { CharacterConfig } from '@noumena-labs/cogent-engine/character';
+
+type ActionSpec = CharacterConfig['actions'][number];
+
+interface ActionGroup {
+  readonly label: string;
+  readonly actionIds: readonly string[];
+}
+
+interface ActionsPanelProps {
+  readonly actions: CharacterConfig['actions'];
+  readonly disabled?: boolean;
+  readonly onTrigger: (actionId: string, cueLabel: string) => void;
+}
+
+const ACTION_GROUPS: readonly ActionGroup[] = [
+  {
+    label: 'Emotes',
+    actionIds: [
+      'wave',
+      'salute',
+      'nod',
+      'shake_head',
+      'thinking',
+      'bashful',
+      'excited',
+      'happy_blissful',
+      'joy_jump',
+      'upset_angry',
+      'crying',
+      'sad_idle',
+    ],
+  },
+  {
+    label: 'Face',
+    actionIds: ['smile', 'look_sad', 'gasp', 'look_angry', 'settle'],
+  },
+  {
+    label: 'Gaze',
+    actionIds: ['look_at_you', 'glance_left', 'glance_right', 'look_up', 'look_down'],
+  },
+  {
+    label: 'Magic',
+    actionIds: ['summon_familiar', 'cast_starbolt', 'raise_ward', 'summon_rune_circle'],
+  },
+];
+
+export function ActionsPanel({ actions, disabled, onTrigger }: ActionsPanelProps) {
+  const actionMap = new Map(actions.map((action) => [action.id, action]));
+  const renderedGroups = ACTION_GROUPS.map((group) => ({
+    ...group,
+    actions: group.actionIds.map((id) => actionMap.get(id)).filter(isActionSpec),
+  })).filter((group) => group.actions.length > 0);
+
+  if (renderedGroups.length === 0) {
+    return null;
+  }
+
+  return (
+    <section className="actions-panel glass-panel" aria-label="Manual avatar actions">
+      <div className="actions-panel-header">
+        <span className="panel-eyebrow">Actions</span>
+        <div className="actions-panel-title">Trigger Aria</div>
+      </div>
+      <div className="actions-panel-groups">
+        {renderedGroups.map((group) => (
+          <div key={group.label} className="action-group">
+            <div className="action-group-label">{group.label}</div>
+            <div className="action-buttons">
+              {group.actions.map((action) => (
+                <button
+                  key={action.id}
+                  type="button"
+                  className={`manual-action-button ${group.label.toLowerCase()}`}
+                  title={action.description ?? action.id}
+                  onClick={() => onTrigger(action.id, action.cue ?? action.id.replace(/_/g, ' '))}
+                  disabled={disabled}
+                >
+                  {formatActionLabel(action.cue ?? action.id)}
+                </button>
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function isActionSpec(action: ActionSpec | undefined): action is ActionSpec {
+  return action != null;
+}
+
+function formatActionLabel(value: string): string {
+  return value
+    .replace(/_/g, ' ')
+    .split(' ')
+    .filter((part) => part.length > 0)
+    .map((part) => part[0].toUpperCase() + part.slice(1))
+    .join(' ');
+}

--- a/apps/avatar/src/components/ActionsPanel.tsx
+++ b/apps/avatar/src/components/ActionsPanel.tsx
@@ -69,7 +69,6 @@ export function ActionsPanel({ actions, disabled, onTrigger }: ActionsPanelProps
     <section className="actions-panel glass-panel" aria-label="Manual avatar actions">
       <div className="actions-panel-header">
         <span className="panel-eyebrow">Actions</span>
-        <div className="actions-panel-title">Trigger Aria</div>
       </div>
       <div className="actions-panel-groups">
         {renderedGroups.map((group) => (

--- a/apps/avatar/src/components/AvatarCanvas.tsx
+++ b/apps/avatar/src/components/AvatarCanvas.tsx
@@ -8,7 +8,7 @@
 //
 //////////////////////////////////////////////////////////////////////////////
 
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useSyncExternalStore } from 'react';
 import type { CharacterEventBus } from '@noumena-labs/cogent-engine/character';
 import { createScene, type SceneHandle } from '../scene/scene';
 import { loadAvatar, type LoadedAvatar } from '../scene/vrm-loader';
@@ -16,6 +16,56 @@ import { ThreeVRMBinding } from '../bindings/three-vrm-binding';
 import { SpeechBubble } from '../scene/speech-bubble';
 import type { AvatarRenderAssets } from '../characters/render-assets';
 import type { ChatMessage } from './chat-types';
+
+interface AvatarCanvasHmrState {
+  sceneEpoch: number;
+  listeners: Set<() => void>;
+}
+
+const avatarCanvasHmrData = import.meta.hot?.data as
+  | { avatarCanvasSceneEpoch?: number }
+  | undefined;
+const avatarCanvasHmrState: AvatarCanvasHmrState = {
+  sceneEpoch: avatarCanvasHmrData?.avatarCanvasSceneEpoch ?? 0,
+  listeners: new Set(),
+};
+
+function subscribeAvatarCanvasSceneEpoch(listener: () => void): () => void {
+  avatarCanvasHmrState.listeners.add(listener);
+  return () => {
+    avatarCanvasHmrState.listeners.delete(listener);
+  };
+}
+
+function getAvatarCanvasSceneEpoch(): number {
+  return avatarCanvasHmrState.sceneEpoch;
+}
+
+function bumpAvatarCanvasSceneEpoch(): void {
+  avatarCanvasHmrState.sceneEpoch += 1;
+  avatarCanvasHmrState.listeners.forEach((listener) => listener());
+}
+
+if (import.meta.hot) {
+  // Remount the imperative scene owner when hot updates land in helpers whose
+  // instances are created inside the long-lived setup effect below.
+  import.meta.hot.accept(
+    [
+      '../bindings/three-vrm-binding',
+      '../scene/scene',
+      '../scene/speech-bubble',
+      '../scene/vrm-loader',
+    ],
+    () => {
+      bumpAvatarCanvasSceneEpoch();
+    }
+  );
+
+  import.meta.hot.dispose((data) => {
+    data.avatarCanvasSceneEpoch = avatarCanvasHmrState.sceneEpoch;
+    avatarCanvasHmrState.listeners.clear();
+  });
+}
 
 interface AvatarCanvasProps {
   readonly bus: CharacterEventBus;
@@ -47,6 +97,11 @@ export function AvatarCanvas({
   const containerRef = useRef<HTMLDivElement | null>(null);
   const bindingRef = useRef<ThreeVRMBinding | null>(null);
   const bubbleRef = useRef<SpeechBubble | null>(null);
+  const sceneEpoch = useSyncExternalStore(
+    subscribeAvatarCanvasSceneEpoch,
+    getAvatarCanvasSceneEpoch,
+    getAvatarCanvasSceneEpoch
+  );
   const speakingRef = useRef(speaking);
   const bubbleTextRef = useRef(bubbleText);
   const bubblePendingRef = useRef(bubblePending);
@@ -179,7 +234,7 @@ export function AvatarCanvas({
       }
       sceneHandle?.dispose();
     };
-  }, [actionNames, bus, characterName, renderAssets]);
+  }, [actionNames, bus, characterName, renderAssets, sceneEpoch]);
 
   return (
     <div className="avatar-canvas" ref={containerRef}>

--- a/apps/avatar/src/components/AvatarCanvas.tsx
+++ b/apps/avatar/src/components/AvatarCanvas.tsx
@@ -163,7 +163,13 @@ export function AvatarCanvas({
         avatar = loaded;
         sceneHandle.avatarRoot.add(loaded.root);
         sceneHandle.focusAvatar(loaded.layout);
-        binding = new ThreeVRMBinding(bus, sceneHandle.scene, loaded, renderAssets);
+        binding = new ThreeVRMBinding(
+          bus,
+          sceneHandle.scene,
+          sceneHandle.camera,
+          loaded,
+          renderAssets
+        );
         await binding.init(actionNames);
         if (cancelled) {
           return;

--- a/apps/avatar/src/components/AvatarCanvas.tsx
+++ b/apps/avatar/src/components/AvatarCanvas.tsx
@@ -15,6 +15,7 @@ import { loadAvatar, type LoadedAvatar } from '../scene/vrm-loader';
 import { ThreeVRMBinding } from '../bindings/three-vrm-binding';
 import { SpeechBubble } from '../scene/speech-bubble';
 import type { AvatarRenderAssets } from '../characters/render-assets';
+import type { ChatMessage } from './chat-types';
 
 interface AvatarCanvasProps {
   readonly bus: CharacterEventBus;
@@ -23,7 +24,10 @@ interface AvatarCanvasProps {
   readonly speaking?: boolean;
   readonly bubbleText?: string;
   readonly bubblePending?: boolean;
+  readonly bubbleActions?: ChatMessage['actions'];
+  readonly characterName?: string;
   readonly status?: string;
+  readonly onReady?: () => void;
   readonly onError?: (message: string) => void;
 }
 
@@ -34,7 +38,10 @@ export function AvatarCanvas({
   speaking = false,
   bubbleText = '',
   bubblePending = false,
+  bubbleActions = [],
+  characterName = 'Aria',
   status,
+  onReady,
   onError,
 }: AvatarCanvasProps) {
   const containerRef = useRef<HTMLDivElement | null>(null);
@@ -43,7 +50,13 @@ export function AvatarCanvas({
   const speakingRef = useRef(speaking);
   const bubbleTextRef = useRef(bubbleText);
   const bubblePendingRef = useRef(bubblePending);
+  const bubbleActionsRef = useRef(bubbleActions);
+  const onReadyRef = useRef(onReady);
   const onErrorRef = useRef(onError);
+
+  useEffect(() => {
+    onReadyRef.current = onReady;
+  }, [onReady]);
 
   useEffect(() => {
     onErrorRef.current = onError;
@@ -57,8 +70,9 @@ export function AvatarCanvas({
   useEffect(() => {
     bubbleTextRef.current = bubbleText;
     bubblePendingRef.current = bubblePending;
-    bubbleRef.current?.setContent(bubbleText, bubblePending);
-  }, [bubblePending, bubbleText]);
+    bubbleActionsRef.current = bubbleActions;
+    bubbleRef.current?.setContent(bubbleText, bubblePending, bubbleActions);
+  }, [bubbleActions, bubblePending, bubbleText]);
 
   useEffect(() => {
     const container = containerRef.current;
@@ -94,22 +108,31 @@ export function AvatarCanvas({
         avatar = loaded;
         sceneHandle.avatarRoot.add(loaded.root);
         sceneHandle.focusAvatar(loaded.layout);
-        binding = new ThreeVRMBinding(bus, loaded, renderAssets);
+        binding = new ThreeVRMBinding(bus, sceneHandle.scene, loaded, renderAssets);
         await binding.init(actionNames);
+        if (cancelled) {
+          return;
+        }
         binding.setSpeaking(speakingRef.current);
         bindingRef.current = binding;
         speechBubble = new SpeechBubble({
           scene: sceneHandle.scene,
           camera: sceneHandle.camera,
           avatar: loaded,
+          speakerName: characterName,
         });
-        speechBubble.setContent(bubbleTextRef.current, bubblePendingRef.current);
+        speechBubble.setContent(
+          bubbleTextRef.current,
+          bubblePendingRef.current,
+          bubbleActionsRef.current
+        );
         bubbleRef.current = speechBubble;
         const offFrame = sceneHandle.onFrame((delta) => {
           binding?.tick(delta);
           speechBubble?.tick(delta);
         });
         (binding as unknown as { _off: () => void })._off = offFrame;
+        onReadyRef.current?.();
       } catch (error) {
         if (!cancelled) {
           if (binding) {
@@ -156,7 +179,7 @@ export function AvatarCanvas({
       }
       sceneHandle?.dispose();
     };
-  }, [actionNames, bus, renderAssets]);
+  }, [actionNames, bus, characterName, renderAssets]);
 
   return (
     <div className="avatar-canvas" ref={containerRef}>

--- a/apps/avatar/src/components/ChatComposer.tsx
+++ b/apps/avatar/src/components/ChatComposer.tsx
@@ -13,12 +13,14 @@ interface ChatComposerProps {
   readonly onSend: (text: string) => void;
   readonly disabled?: boolean;
   readonly characterName?: string;
+  readonly suggestions?: readonly string[];
 }
 
 export function ChatComposer({
   onSend,
   disabled,
   characterName = 'your companion',
+  suggestions = [],
 }: ChatComposerProps) {
   const [draft, setDraft] = useState('');
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
@@ -53,6 +55,14 @@ export function ChatComposer({
     }
   };
 
+  const sendSuggestion = (suggestion: string): void => {
+    if (disabled) {
+      return;
+    }
+    onSend(suggestion);
+    setDraft('');
+  };
+
   return (
     <form className="chat-composer glass-panel" onSubmit={handleSubmit}>
       <div className="chat-composer-header">
@@ -62,6 +72,21 @@ export function ChatComposer({
         </div>
         <div className="chat-composer-hint">Enter to send</div>
       </div>
+      {suggestions.length > 0 ? (
+        <div className="prompt-suggestions" aria-label="Suggested prompts">
+          {suggestions.map((suggestion) => (
+            <button
+              key={suggestion}
+              type="button"
+              className="prompt-chip"
+              onClick={() => sendSuggestion(suggestion)}
+              disabled={disabled}
+            >
+              {suggestion}
+            </button>
+          ))}
+        </div>
+      ) : null}
       <div className="chat-composer-row">
         <textarea
           ref={textareaRef}

--- a/apps/avatar/src/components/ControlsPanel.tsx
+++ b/apps/avatar/src/components/ControlsPanel.tsx
@@ -2,9 +2,8 @@
 //
 // ControlsPanel.tsx
 //
-// - Lets the user point at a character.json + a model URL and trigger
-//   engine load. Intentionally minimal — this is an example harness, not a
-//   production settings page.
+// - Lets the user point at a model URL and trigger engine load. Character
+//   config is owned internally by the demo.
 //
 //////////////////////////////////////////////////////////////////////////////
 
@@ -12,19 +11,17 @@ import type { FormEvent } from 'react';
 import { useEffect, useState } from 'react';
 
 interface ControlsPanelProps {
-  readonly characterUrl: string;
   readonly modelUrl: string;
   readonly characterName?: string;
   readonly personaSummary?: string;
   readonly status: string;
   readonly busy: boolean;
   readonly loaded: boolean;
-  readonly onLoad: (args: { characterUrl: string; modelUrl: string }) => void;
+  readonly onLoad: (args: { modelUrl: string }) => void;
   readonly onReset?: () => void;
 }
 
 export function ControlsPanel({
-  characterUrl,
   modelUrl,
   characterName = 'Companion',
   personaSummary = 'A warm, playful stage companion.',
@@ -34,12 +31,7 @@ export function ControlsPanel({
   onLoad,
   onReset,
 }: ControlsPanelProps) {
-  const [cfg, setCfg] = useState(characterUrl);
   const [model, setModel] = useState(modelUrl);
-
-  useEffect(() => {
-    setCfg(characterUrl);
-  }, [characterUrl]);
 
   useEffect(() => {
     setModel(modelUrl);
@@ -47,10 +39,10 @@ export function ControlsPanel({
 
   const handleSubmit = (event: FormEvent): void => {
     event.preventDefault();
-    if (busy || cfg.trim().length === 0 || model.trim().length === 0) {
+    if (busy || model.trim().length === 0) {
       return;
     }
-    onLoad({ characterUrl: cfg.trim(), modelUrl: model.trim() });
+    onLoad({ modelUrl: model.trim() });
   };
 
   return (
@@ -71,16 +63,6 @@ export function ControlsPanel({
       <form className="controls-form" onSubmit={handleSubmit}>
         <div className="controls-fields">
           <label className="field-label">
-            <span>character.json URL</span>
-            <input
-              type="text"
-              value={cfg}
-              onChange={(event) => setCfg(event.target.value)}
-              disabled={busy}
-              placeholder="/characters/aria/character.json"
-            />
-          </label>
-          <label className="field-label">
             <span>Model (.gguf) URL</span>
             <input
               type="url"
@@ -93,8 +75,8 @@ export function ControlsPanel({
         </div>
 
         <div className="controls-toolbar">
-          <button type="submit" disabled={busy || cfg.trim().length === 0 || model.trim().length === 0}>
-            {loaded ? 'Reload Model' : 'Load Character + Model'}
+          <button type="submit" disabled={busy || model.trim().length === 0}>
+            {loaded ? 'Reload Model' : 'Load Model'}
           </button>
           {loaded && onReset ? (
             <button type="button" className="secondary-button" onClick={onReset} disabled={busy}>

--- a/apps/avatar/src/components/StartScreen.tsx
+++ b/apps/avatar/src/components/StartScreen.tsx
@@ -1,0 +1,102 @@
+//////////////////////////////////////////////////////////////////////////////
+//
+// StartScreen.tsx
+//
+// - Presents the avatar demo as a start menu and owns the initial model URL
+//   entry before the interactive experience is unlocked.
+//
+//////////////////////////////////////////////////////////////////////////////
+
+import type { FormEvent } from 'react';
+import { useEffect, useState } from 'react';
+
+interface StartScreenProps {
+  readonly modelUrl: string;
+  readonly characterName?: string;
+  readonly personaSummary?: string;
+  readonly status: string;
+  readonly busy: boolean;
+  readonly onStart: (args: { modelUrl: string }) => void | Promise<void>;
+}
+
+export function StartScreen({
+  modelUrl,
+  characterName = 'Aria',
+  personaSummary = 'A warm, playful stage companion.',
+  status,
+  busy,
+  onStart,
+}: StartScreenProps) {
+  const [model, setModel] = useState(modelUrl);
+
+  useEffect(() => {
+    setModel(modelUrl);
+  }, [modelUrl]);
+
+  const trimmedModel = model.trim();
+
+  const handleSubmit = (event: FormEvent): void => {
+    event.preventDefault();
+    if (busy || trimmedModel.length === 0) {
+      return;
+    }
+    void onStart({ modelUrl: trimmedModel });
+  };
+
+  return (
+    <div className="start-screen">
+      <section className="start-card glass-panel" aria-labelledby="start-title">
+        <div className="start-hero">
+          <span className="panel-eyebrow">Cogent Avatar Demo</span>
+          <h1 id="start-title">Enter the Starfall Gate</h1>
+          <p className="start-lede">
+            Meet {characterName}, a real-time character experience powered by a local LLM.
+            CogentEngine runs the selected GGUF model locally, connects it to a
+            high-performance backend, and drives a dynamic avatar scene with chat, memory,
+            animations, and world effects.
+          </p>
+        </div>
+
+        <div className="start-character-card">
+          <span className="start-character-label">Featured companion</span>
+          <strong>{characterName}</strong>
+          <p>{personaSummary}</p>
+        </div>
+       
+        {/* 
+        <div className="start-feature-list" aria-label="Experience features">
+          <span>Local GGUF model</span>
+          <span>High-performance runtime</span>
+          <span>Dynamic avatar actions</span>
+        </div> */}
+
+        <form className="start-model-form" onSubmit={handleSubmit}>
+          <label className="field-label">
+            <span>Model (.gguf) URL</span>
+            <input
+              type="url"
+              value={model}
+              onChange={(event) => setModel(event.target.value)}
+              disabled={busy}
+              placeholder="https://huggingface.co/.../model.gguf"
+            />
+          </label>
+
+
+
+          <button
+            className="start-button"
+            type="submit"
+            disabled={busy || trimmedModel.length === 0}
+          >
+            {busy ? 'Starting' : 'Start'}
+          </button>
+
+          <div className="start-status" aria-live="polite">
+           {status}
+        </div>
+        </form>
+      </section>
+    </div>
+  );
+}

--- a/apps/avatar/src/components/TranscriptDrawer.tsx
+++ b/apps/avatar/src/components/TranscriptDrawer.tsx
@@ -36,12 +36,6 @@ export function TranscriptDrawer({
 
   return (
     <>
-      <button
-        type="button"
-        className={`transcript-backdrop${open ? ' open' : ''}`}
-        onClick={onClose}
-        aria-label="Close transcript drawer"
-      />
       <aside
         id={id}
         className={`transcript-drawer glass-panel${open ? ' open' : ''}`}
@@ -53,7 +47,7 @@ export function TranscriptDrawer({
             <h2>{characterName}'s transcript</h2>
           </div>
           <button type="button" className="secondary-button" onClick={onClose}>
-            Close
+            Minimize
           </button>
         </div>
 

--- a/apps/avatar/src/components/TranscriptDrawer.tsx
+++ b/apps/avatar/src/components/TranscriptDrawer.tsx
@@ -44,7 +44,7 @@ export function TranscriptDrawer({
         <div className="transcript-header">
           <div>
             <span className="panel-eyebrow">Conversation</span>
-            <h2>{characterName}'s transcript</h2>
+            <h2>Chat transcript</h2>
           </div>
           <button type="button" className="secondary-button" onClick={onClose}>
             Minimize

--- a/apps/avatar/src/scene/scene.ts
+++ b/apps/avatar/src/scene/scene.ts
@@ -29,6 +29,11 @@ export interface SceneHandle {
 const DEFAULT_FOCUS = new THREE.Vector3(0, 1.3, 0);
 const MIN_CAMERA_DISTANCE = 1.7;
 const CAMERA_PADDING = 1.35;
+const CAMERA_VERTICAL_BIAS = 0.18;
+
+interface FantasyEnvironment {
+  update(deltaSeconds: number, elapsedSeconds: number): void;
+}
 
 export function createScene(container: HTMLElement): SceneHandle {
   const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true });
@@ -42,27 +47,26 @@ export function createScene(container: HTMLElement): SceneHandle {
   camera.position.set(0, DEFAULT_FOCUS.y + 0.05, 2.4);
   camera.lookAt(DEFAULT_FOCUS);
 
-  // Lighting — a hemisphere for fill and a directional for shape.
-  const hemi = new THREE.HemisphereLight(0xffffff, 0x223344, 0.9);
-  scene.add(hemi);
-  const dir = new THREE.DirectionalLight(0xffffff, 1.1);
-  dir.position.set(2, 3, 2);
-  scene.add(dir);
+  scene.fog = new THREE.FogExp2(0x080716, 0.058);
 
-  // Ground shadow disc — cheap visual anchor without enabling shadow maps.
-  const disc = new THREE.Mesh(
-    new THREE.CircleGeometry(0.8, 32),
-    new THREE.MeshBasicMaterial({ color: 0x000000, transparent: true, opacity: 0.25 })
-  );
-  disc.rotation.x = -Math.PI / 2;
-  disc.position.y = 0.001;
-  scene.add(disc);
+  // Moonlit fantasy stage lighting: cool ambient, warm key, violet rim.
+  const hemi = new THREE.HemisphereLight(0xdfeaff, 0x12091f, 0.72);
+  scene.add(hemi);
+  const dir = new THREE.DirectionalLight(0xffe1a8, 1.05);
+  dir.position.set(-2.4, 4, 2.2);
+  scene.add(dir);
+  const rim = new THREE.DirectionalLight(0x9574ff, 1.4);
+  rim.position.set(2.8, 2.4, -1.6);
+  scene.add(rim);
+
+  const environment = createFantasyEnvironment(scene);
 
   const avatarRoot = new THREE.Group();
   scene.add(avatarRoot);
 
   const callbacks = new Set<(deltaSeconds: number) => void>();
   const clock = new THREE.Clock();
+  let elapsedSeconds = 0;
   const currentFocus = DEFAULT_FOCUS.clone();
   let lastLayout: AvatarLayout | null = null;
   let disposed = false;
@@ -72,6 +76,8 @@ export function createScene(container: HTMLElement): SceneHandle {
       return;
     }
     const delta = clock.getDelta();
+    elapsedSeconds += delta;
+    environment.update(delta, elapsedSeconds);
     for (const cb of callbacks) {
       cb(delta);
     }
@@ -103,7 +109,8 @@ export function createScene(container: HTMLElement): SceneHandle {
       Math.max(MIN_CAMERA_DISTANCE, Math.max(distanceForHeight, distanceForWidth) * CAMERA_PADDING)
     );
     currentFocus.copy(focus);
-    camera.position.set(0, focus.y + layout.height * 0.03, distance);
+    currentFocus.y += layout.height * CAMERA_VERTICAL_BIAS;
+    camera.position.set(0, focus.y + layout.height * (0.03 + CAMERA_VERTICAL_BIAS), distance);
     camera.lookAt(currentFocus);
     camera.near = 0.1;
     camera.far = Math.max(20, distance + layout.height * 4);
@@ -144,4 +151,151 @@ export function createScene(container: HTMLElement): SceneHandle {
       });
     },
   };
+}
+
+function createFantasyEnvironment(scene: THREE.Scene): FantasyEnvironment {
+  const runeRing = new THREE.Group();
+  const moteGeometry = new THREE.BufferGeometry();
+  const moteCount = 90;
+  const motePositions = new Float32Array(moteCount * 3);
+  const moteSeeds = Array.from({ length: moteCount }, () => Math.random());
+
+  const stone = new THREE.MeshStandardMaterial({
+    color: 0x40344d,
+    roughness: 0.92,
+    metalness: 0.02,
+  });
+  const stoneDark = new THREE.MeshStandardMaterial({
+    color: 0x231d32,
+    roughness: 0.96,
+  });
+  const rune = new THREE.MeshBasicMaterial({
+    color: 0x8dfce7,
+    transparent: true,
+    opacity: 0.46,
+    blending: THREE.AdditiveBlending,
+    depthWrite: false,
+  });
+  const crystal = new THREE.MeshStandardMaterial({
+    color: 0x76f7e4,
+    emissive: 0x2adbbf,
+    emissiveIntensity: 1.4,
+    roughness: 0.34,
+    metalness: 0.08,
+    transparent: true,
+    opacity: 0.82,
+  });
+
+  const dais = new THREE.Mesh(new THREE.CylinderGeometry(1.12, 1.2, 0.1, 80), stone);
+  dais.position.y = -0.052;
+  scene.add(dais);
+
+  const daisLip = new THREE.Mesh(new THREE.TorusGeometry(1.14, 0.018, 10, 96), stoneDark);
+  daisLip.rotation.x = Math.PI / 2;
+  daisLip.position.y = 0.005;
+  scene.add(daisLip);
+
+  const innerRune = new THREE.Mesh(new THREE.TorusGeometry(0.84, 0.006, 8, 96), rune);
+  const outerRune = new THREE.Mesh(new THREE.TorusGeometry(1.0, 0.008, 8, 96), rune.clone());
+  innerRune.rotation.x = Math.PI / 2;
+  outerRune.rotation.x = Math.PI / 2;
+  innerRune.position.y = 0.008;
+  outerRune.position.y = 0.01;
+  runeRing.add(innerRune, outerRune);
+
+  const sigilGeometry = new THREE.BoxGeometry(0.018, 0.12, 0.006);
+  for (let index = 0; index < 18; index += 1) {
+    const angle = (index / 18) * Math.PI * 2;
+    const mark = new THREE.Mesh(sigilGeometry, rune.clone());
+    mark.position.set(Math.cos(angle) * 0.93, 0.012, Math.sin(angle) * 0.93);
+    mark.rotation.set(-Math.PI / 2, 0, -angle);
+    runeRing.add(mark);
+  }
+  scene.add(runeRing);
+
+  addBrokenPillar(scene, -1.55, -0.42, 1.18, stone, stoneDark);
+  addBrokenPillar(scene, 1.46, -0.55, 0.88, stone, stoneDark);
+  addBrokenPillar(scene, -1.18, -1.12, 0.72, stone, stoneDark);
+  addBrokenPillar(scene, 1.34, -1.22, 1.36, stone, stoneDark);
+
+  addCrystalCluster(scene, -1.05, 0.36, 0.44, crystal);
+  addCrystalCluster(scene, 1.05, 0.28, 0.36, crystal.clone());
+  const crystalLight = new THREE.PointLight(0x63ffe5, 1.6, 4.2);
+  crystalLight.position.set(0, 0.46, 0.28);
+  scene.add(crystalLight);
+
+  for (let index = 0; index < moteCount; index += 1) {
+    const radius = 0.8 + moteSeeds[index] * 2.1;
+    const angle = moteSeeds[index] * Math.PI * 2 * 7.3;
+    motePositions[index * 3] = Math.cos(angle) * radius;
+    motePositions[index * 3 + 1] = 0.45 + Math.random() * 2.25;
+    motePositions[index * 3 + 2] = Math.sin(angle) * radius - 0.6;
+  }
+  moteGeometry.setAttribute('position', new THREE.BufferAttribute(motePositions, 3));
+  const motes = new THREE.Points(
+    moteGeometry,
+    new THREE.PointsMaterial({
+      color: 0xffe4a3,
+      size: 0.025,
+      transparent: true,
+      opacity: 0.62,
+      blending: THREE.AdditiveBlending,
+      depthWrite: false,
+    })
+  );
+  scene.add(motes);
+
+  return {
+    update(_deltaSeconds, elapsedSeconds) {
+      runeRing.rotation.y = elapsedSeconds * 0.08;
+      innerRune.scale.setScalar(1 + Math.sin(elapsedSeconds * 1.2) * 0.015);
+      outerRune.scale.setScalar(1 + Math.cos(elapsedSeconds * 1.1) * 0.012);
+      crystalLight.intensity = 1.35 + Math.sin(elapsedSeconds * 2.1) * 0.24;
+      const positions = moteGeometry.getAttribute('position') as THREE.BufferAttribute;
+      for (let index = 0; index < moteCount; index += 1) {
+        const seed = moteSeeds[index];
+        positions.setY(index, 0.45 + ((elapsedSeconds * (0.08 + seed * 0.08) + seed * 3.8) % 2.35));
+        positions.setX(index, motePositions[index * 3] + Math.sin(elapsedSeconds * 0.7 + seed * 20) * 0.035);
+      }
+      positions.needsUpdate = true;
+    },
+  };
+}
+
+function addBrokenPillar(
+  scene: THREE.Scene,
+  x: number,
+  z: number,
+  height: number,
+  stone: THREE.Material,
+  capMaterial: THREE.Material
+): void {
+  const shaft = new THREE.Mesh(new THREE.CylinderGeometry(0.13, 0.16, height, 7), stone);
+  shaft.position.set(x, height / 2 - 0.04, z);
+  shaft.rotation.z = (Math.random() - 0.5) * 0.18;
+  scene.add(shaft);
+
+  const cap = new THREE.Mesh(new THREE.CylinderGeometry(0.19, 0.19, 0.08, 7), capMaterial);
+  cap.position.set(x + 0.02, height - 0.02, z - 0.015);
+  cap.rotation.set(0.1, 0.2, shaft.rotation.z + 0.05);
+  scene.add(cap);
+}
+
+function addCrystalCluster(
+  scene: THREE.Scene,
+  x: number,
+  z: number,
+  scale: number,
+  material: THREE.Material
+): void {
+  const geometry = new THREE.ConeGeometry(0.12, 0.62, 5);
+  for (let index = 0; index < 4; index += 1) {
+    const shard = new THREE.Mesh(geometry, material);
+    const angle = (index / 4) * Math.PI * 2;
+    const radius = index === 0 ? 0 : 0.12;
+    shard.position.set(x + Math.cos(angle) * radius, 0.25 * scale, z + Math.sin(angle) * radius);
+    shard.scale.setScalar(scale * (index === 0 ? 1.15 : 0.74));
+    shard.rotation.set((Math.random() - 0.5) * 0.26, angle, (Math.random() - 0.5) * 0.22);
+    scene.add(shard);
+  }
 }

--- a/apps/avatar/src/scene/speech-bubble.ts
+++ b/apps/avatar/src/scene/speech-bubble.ts
@@ -252,7 +252,7 @@ function drawDialogueWindow(
   context.fill();
 
   context.lineJoin = 'round';
-  context.lineWidth = 20;
+  context.lineWidth = 2;
   context.strokeStyle = 'rgba(255, 255, 255, 0.22)';
   context.stroke();
   context.lineWidth = 6;

--- a/apps/avatar/src/scene/speech-bubble.ts
+++ b/apps/avatar/src/scene/speech-bubble.ts
@@ -2,137 +2,52 @@
 //
 // speech-bubble.ts
 //
-// - Renders a fluffy, hovering white cloud above the avatar head.
-// - Cloud silhouette built from a cluster of overlapping spheres with an
-//   unlit soft-white shader (subtle vertical gradient + rim feathering).
-// - Streamed assistant text drawn to a CanvasTexture on a transparent plane
-//   tucked inside the cloud silhouette.
+// - Renders an opaque JRPG-style dialogue window near the avatar.
+// - The full panel is drawn into one CanvasTexture so the border, fill,
+//   nameplate, tail, and text stay visually cohesive.
 //
 //////////////////////////////////////////////////////////////////////////////
 
 import * as THREE from 'three';
+import type { ChatMessage } from '../components/chat-types';
 import type { LoadedAvatar } from './vrm-loader';
 import { getAvatarHeadNode } from './vrm-loader';
 
-const CANVAS_WIDTH = 1024;
-const CANVAS_HEIGHT = 320;
-const MAX_LINES = 5;
+const CANVAS_WIDTH = 1400;
+const CANVAS_HEIGHT = 420;
+const MAX_LINES = 4;
 const TEXT_FONT = '600 38px "Trebuchet MS", "Segoe UI", sans-serif';
-const TEXT_LINE_HEIGHT = 46;
-const TEXT_AREA_WIDTH = 820;
-const FLOAT_SPEED = 1.4;
-const FLOAT_AMPLITUDE = 0.028;
-const BUBBLE_SCALE_MULTIPLIER = 0.5;
-const BUBBLE_CAMERA_PULL = 0.08;
-const BUBBLE_HORIZONTAL_RATIO = 0.3;
-const BUBBLE_VERTICAL_RATIO = 0.16;
-const BUBBLE_VERTICAL_BIAS = 0.15;
-
-// Unlit cloud shader: soft white body with a gentle top-to-bottom gradient
-// and a feathered rim that fades at glancing angles, giving volumetric read.
-const CLOUD_VERTEX_SHADER = `
-varying vec3 vNormal;
-varying vec3 vViewDir;
-varying vec3 vLocalPos;
-
-void main() {
-  vLocalPos = position;
-  vec4 worldPos = modelMatrix * vec4(position, 1.0);
-  vec4 viewPos = viewMatrix * worldPos;
-  vNormal = normalize(normalMatrix * normal);
-  vViewDir = normalize(-viewPos.xyz);
-  gl_Position = projectionMatrix * viewPos;
-}
-`;
-
-const CLOUD_FRAGMENT_SHADER = `
-uniform vec3 uTopColor;
-uniform vec3 uBottomColor;
-uniform vec3 uShadowColor;
-uniform float uOpacity;
-uniform float uGradientCenter;
-
-varying vec3 vNormal;
-varying vec3 vViewDir;
-varying vec3 vLocalPos;
-
-void main() {
-  vec3 n = normalize(vNormal);
-  vec3 v = normalize(vViewDir);
-  float facing = clamp(dot(n, v), 0.0, 1.0);
-
-  // Vertical gradient across the puff: brighter near the top, softly
-  // shadowed underneath so the cloud reads as lit from above.
-  float vertical = clamp(vLocalPos.y / max(uGradientCenter, 0.0001) * 0.5 + 0.5, 0.0, 1.0);
-  float gradient = smoothstep(0.1, 0.9, vertical);
-  vec3 base = mix(uBottomColor, uTopColor, gradient);
-
-  // Under-shadow on the bottom faces, very subtle.
-  float underShadow = smoothstep(0.55, 0.0, vertical) * 0.22;
-  base = mix(base, uShadowColor, underShadow);
-
-  // Feather the silhouette so sphere seams dissolve into the cloud edge.
-  float edge = pow(facing, 1.6);
-  float alpha = uOpacity * smoothstep(0.02, 0.55, edge);
-
-  gl_FragColor = vec4(base, alpha);
-}
-`;
+const NAME_FONT = '800 26px "Trebuchet MS", "Segoe UI", sans-serif';
+const ACTION_FONT = '800 21px "Trebuchet MS", "Segoe UI", sans-serif';
+const TEXT_LINE_HEIGHT = 49;
+const TEXT_AREA_WIDTH = 1040;
+const TEXT_START_X = 172;
+const TEXT_CENTER_Y = 252;
+const FLOAT_SPEED = 1.05;
+const FLOAT_AMPLITUDE = 0.014;
+const PANEL_SCALE_MULTIPLIER = 0.66;
+const PANEL_CAMERA_PULL = 0.1;
+const PANEL_HORIZONTAL_RATIO = 0.18;
+const PANEL_VERTICAL_RATIO = 0.24;
+const PANEL_VERTICAL_BIAS = 0.24;
 
 interface SpeechBubbleOptions {
   readonly scene: THREE.Scene;
   readonly camera: THREE.PerspectiveCamera;
   readonly avatar: LoadedAvatar;
+  readonly speakerName?: string;
 }
 
-interface CloudUniforms {
-  readonly uTopColor: THREE.IUniform<THREE.Color>;
-  readonly uBottomColor: THREE.IUniform<THREE.Color>;
-  readonly uShadowColor: THREE.IUniform<THREE.Color>;
-  readonly uOpacity: THREE.IUniform<number>;
-  readonly uGradientCenter: THREE.IUniform<number>;
-  readonly [key: string]: THREE.IUniform<unknown>;
-}
-
-type CloudMaterial = THREE.ShaderMaterial & {
-  readonly uniforms: CloudUniforms;
-};
-
-interface CloudPuff {
-  readonly x: number;
-  readonly y: number;
-  readonly z: number;
-  readonly radius: number;
-}
-
-// Hand-authored cluster that reads as a rounded, slightly wider-than-tall
-// cartoon cloud. Coordinates are in the bubble's local space; Y up.
-const CLOUD_PUFFS: readonly CloudPuff[] = [
-  { x: 0.0, y: 0.02, z: 0.0, radius: 0.46 },
-  { x: -0.52, y: -0.02, z: 0.0, radius: 0.38 },
-  { x: 0.52, y: -0.02, z: 0.0, radius: 0.38 },
-  { x: -0.28, y: 0.26, z: 0.04, radius: 0.34 },
-  { x: 0.28, y: 0.26, z: 0.04, radius: 0.34 },
-  { x: -0.78, y: -0.08, z: -0.02, radius: 0.26 },
-  { x: 0.78, y: -0.08, z: -0.02, radius: 0.26 },
-  { x: 0.0, y: 0.34, z: 0.02, radius: 0.3 },
-  { x: -0.18, y: -0.26, z: 0.02, radius: 0.3 },
-  { x: 0.22, y: -0.28, z: 0.02, radius: 0.3 },
-  { x: -0.6, y: -0.26, z: 0.0, radius: 0.22 },
-  { x: 0.6, y: -0.26, z: 0.0, radius: 0.22 },
-];
-
-const CLOUD_HALF_HEIGHT = 0.55;
+type SpeechBubbleAction = ChatMessage['actions'][number];
 
 export class SpeechBubble {
   private readonly scene: THREE.Scene;
   private readonly camera: THREE.PerspectiveCamera;
   private readonly avatar: LoadedAvatar;
+  private readonly speakerName: string;
   private readonly headNode: THREE.Object3D | null;
   private readonly root = new THREE.Group();
-  private readonly cloudGroup = new THREE.Group();
-  private readonly cloudMaterial: CloudMaterial;
-  private readonly faceMaterial: THREE.MeshBasicMaterial;
+  private readonly material: THREE.MeshBasicMaterial;
   private readonly canvas: HTMLCanvasElement;
   private readonly context: CanvasRenderingContext2D;
   private readonly texture: THREE.CanvasTexture;
@@ -142,19 +57,21 @@ export class SpeechBubble {
   private readonly scale: number;
   private text = '';
   private pending = false;
+  private actions: readonly SpeechBubbleAction[] = [];
   private dirty = true;
   private visibility = 0;
   private targetVisibility = 0;
   private elapsedSeconds = 0;
 
-  public constructor({ scene, camera, avatar }: SpeechBubbleOptions) {
+  public constructor({ scene, camera, avatar, speakerName = 'Aria' }: SpeechBubbleOptions) {
     this.scene = scene;
     this.camera = camera;
     this.avatar = avatar;
+    this.speakerName = speakerName;
     this.headNode = getAvatarHeadNode(avatar);
     this.scale =
-      THREE.MathUtils.clamp(this.avatar.layout.height / 1.8, 0.86, 1.16) *
-      BUBBLE_SCALE_MULTIPLIER;
+      THREE.MathUtils.clamp(this.avatar.layout.height / 1.8, 0.88, 1.18) *
+      PANEL_SCALE_MULTIPLIER;
 
     this.canvas = document.createElement('canvas');
     this.canvas.width = CANVAS_WIDTH;
@@ -171,52 +88,43 @@ export class SpeechBubble {
     this.texture.magFilter = THREE.LinearFilter;
     this.texture.generateMipmaps = false;
 
-    this.cloudMaterial = createCloudMaterial();
+    this.material = new THREE.MeshBasicMaterial({
+      map: this.texture,
+      transparent: true,
+      opacity: 0,
+      depthWrite: false,
+      depthTest: true,
+      toneMapped: false,
+    });
 
-    const puffGeometry = new THREE.SphereGeometry(1, 32, 24);
-    for (const puff of CLOUD_PUFFS) {
-      const mesh = new THREE.Mesh(puffGeometry, this.cloudMaterial);
-      mesh.position.set(puff.x, puff.y, puff.z);
-      mesh.scale.setScalar(puff.radius);
-      mesh.renderOrder = 10;
-      this.cloudGroup.add(mesh);
-    }
-
-    const face = new THREE.Mesh(
-      new THREE.PlaneGeometry(1.6, 0.62),
-      new THREE.MeshBasicMaterial({
-        map: this.texture,
-        transparent: true,
-        opacity: 0,
-        depthWrite: false,
-        depthTest: true,
-        toneMapped: false,
-      })
-    );
-    face.position.set(0, 0.04, 0.48);
-    face.renderOrder = 12;
-    this.faceMaterial = face.material as THREE.MeshBasicMaterial;
-
-    this.root.add(this.cloudGroup, face);
+    const panel = new THREE.Mesh(new THREE.PlaneGeometry(2.28, 0.68), this.material);
+    panel.renderOrder = 20;
+    this.root.add(panel);
     this.root.scale.setScalar(this.scale);
     this.root.visible = false;
     this.scene.add(this.root);
+    this.redraw();
   }
 
-  public setContent(text: string, pending: boolean): void {
+  public setContent(
+    text: string,
+    pending: boolean,
+    actions: readonly SpeechBubbleAction[] = []
+  ): void {
     const nextText = text.trim();
-    if (this.text === nextText && this.pending === pending) {
+    if (this.text === nextText && this.pending === pending && sameActions(this.actions, actions)) {
       return;
     }
     this.text = nextText;
     this.pending = pending;
+    this.actions = actions;
     this.targetVisibility = nextText.length > 0 || pending ? 1 : 0;
     this.dirty = true;
   }
 
   public tick(deltaSeconds: number): void {
     this.elapsedSeconds += deltaSeconds;
-    this.visibility = THREE.MathUtils.damp(this.visibility, this.targetVisibility, 9, deltaSeconds);
+    this.visibility = THREE.MathUtils.damp(this.visibility, this.targetVisibility, 10, deltaSeconds);
     if (this.dirty) {
       this.redraw();
       this.dirty = false;
@@ -230,7 +138,7 @@ export class SpeechBubble {
     this.root.visible = true;
     this.root.quaternion.copy(this.camera.quaternion);
     this.updatePosition();
-    this.updateMaterials();
+    this.material.opacity = easeOutCubic(this.visibility);
   }
 
   public dispose(): void {
@@ -260,24 +168,23 @@ export class SpeechBubble {
       return;
     }
 
+    drawDialogueWindow(context, this.speakerName, this.actions);
+
     context.font = TEXT_FONT;
     context.textBaseline = 'alphabetic';
-    context.fillStyle = '#2a2550';
-    context.shadowColor = 'rgba(255, 255, 255, 0.9)';
-    context.shadowBlur = 10;
-    context.shadowOffsetX = 0;
-    context.shadowOffsetY = 0;
+    context.fillStyle = '#fff9e8';
+    context.shadowColor = 'rgba(0, 0, 0, 0.82)';
+    context.shadowBlur = 5;
+    context.shadowOffsetX = 2;
+    context.shadowOffsetY = 3;
 
     const { lines, truncated } = wrapText(context, displayText, TEXT_AREA_WIDTH, MAX_LINES);
     const bubbleLines = truncated ? appendEllipsis(lines) : lines;
-
     const totalHeight = bubbleLines.length * TEXT_LINE_HEIGHT;
-    const startY = (CANVAS_HEIGHT - totalHeight) / 2 + TEXT_LINE_HEIGHT * 0.75;
+    const startY = TEXT_CENTER_Y - totalHeight / 2 + TEXT_LINE_HEIGHT * 0.76;
 
     bubbleLines.forEach((line, index) => {
-      const metrics = context.measureText(line);
-      const x = (CANVAS_WIDTH - metrics.width) / 2;
-      context.fillText(line, x, startY + index * TEXT_LINE_HEIGHT);
+      context.fillText(line, TEXT_START_X, startY + index * TEXT_LINE_HEIGHT);
     });
 
     context.shadowBlur = 0;
@@ -295,44 +202,187 @@ export class SpeechBubble {
       .copy(this.camera.position)
       .sub(this.headWorld)
       .normalize()
-      .multiplyScalar(BUBBLE_CAMERA_PULL);
-    const verticalOffset = this.avatar.layout.height * BUBBLE_VERTICAL_RATIO + BUBBLE_VERTICAL_BIAS;
+      .multiplyScalar(PANEL_CAMERA_PULL);
+    const verticalOffset = this.avatar.layout.height * PANEL_VERTICAL_RATIO + PANEL_VERTICAL_BIAS;
     const floatOffset = Math.sin(this.elapsedSeconds * FLOAT_SPEED) * FLOAT_AMPLITUDE;
-    const driftX = Math.sin(this.elapsedSeconds * FLOAT_SPEED * 0.6) * 0.012;
+    const driftX = Math.sin(this.elapsedSeconds * FLOAT_SPEED * 0.5) * 0.006;
 
     this.worldTarget.copy(this.headWorld);
     this.worldTarget.x += this.cameraOffset.x + driftX;
-    this.worldTarget.x += this.avatar.layout.height * BUBBLE_HORIZONTAL_RATIO;
+    this.worldTarget.x += this.avatar.layout.height * PANEL_HORIZONTAL_RATIO;
     this.worldTarget.y += verticalOffset + floatOffset;
     this.worldTarget.z += this.cameraOffset.z;
     this.root.position.copy(this.worldTarget);
-    this.root.scale.setScalar(this.scale * (0.95 + this.visibility * 0.05));
-  }
-
-  private updateMaterials(): void {
-    this.cloudMaterial.uniforms.uOpacity.value = this.visibility;
-    this.faceMaterial.opacity = this.visibility;
+    this.root.scale.setScalar(this.scale * (0.97 + this.visibility * 0.03));
   }
 }
 
-function createCloudMaterial(): CloudMaterial {
-  const uniforms: CloudUniforms = {
-    uTopColor: { value: new THREE.Color('#ffffff') },
-    uBottomColor: { value: new THREE.Color('#eef2ff') },
-    uShadowColor: { value: new THREE.Color('#c9d3ef') },
-    uOpacity: { value: 0 },
-    uGradientCenter: { value: CLOUD_HALF_HEIGHT },
-  };
+function drawDialogueWindow(
+  context: CanvasRenderingContext2D,
+  speakerName: string,
+  actions: readonly SpeechBubbleAction[]
+): void {
+  const panelX = 68;
+  const panelY = 74;
+  const panelW = 1264;
+  const panelH = 270;
+  const tailX = 275;
+  const tailTopY = panelY + panelH - 4;
 
-  return new THREE.ShaderMaterial({
-    uniforms,
-    vertexShader: CLOUD_VERTEX_SHADER,
-    fragmentShader: CLOUD_FRAGMENT_SHADER,
-    transparent: true,
-    depthWrite: false,
-    depthTest: true,
-    toneMapped: false,
-  }) as CloudMaterial;
+  context.save();
+  context.shadowColor = 'rgba(0, 0, 0, 0.48)';
+  context.shadowBlur = 22;
+  context.shadowOffsetY = 12;
+
+  context.beginPath();
+  roundedRectPath(context, panelX, panelY, panelW, panelH, 16);
+  context.moveTo(tailX, tailTopY);
+  context.lineTo(tailX + 72, tailTopY);
+  context.lineTo(tailX + 26, tailTopY + 72);
+  context.closePath();
+  context.fillStyle = '#050717';
+  context.fill();
+
+  const fillGradient = context.createLinearGradient(0, panelY, 0, panelY + panelH);
+  fillGradient.addColorStop(0, '#171d4b');
+  fillGradient.addColorStop(0.5, '#0e1330');
+  fillGradient.addColorStop(1, '#06091d');
+  context.shadowBlur = 0;
+  context.fillStyle = fillGradient;
+  context.fill();
+
+  context.lineJoin = 'round';
+  context.lineWidth = 20;
+  context.strokeStyle = 'rgba(255, 255, 255, 0.22)';
+  context.stroke();
+  context.lineWidth = 6;
+  context.strokeStyle = '#fffaf0';
+  context.stroke();
+  context.lineWidth = 4;
+  context.strokeStyle = '#97a0ff';
+  context.stroke();
+
+  context.globalAlpha = 0.5;
+  context.beginPath();
+  roundedRectPath(context, panelX + 38, panelY + 38, panelW - 76, panelH - 76, 9);
+  context.strokeStyle = '#dfe4ff';
+  context.lineWidth = 3;
+  context.stroke();
+  context.globalAlpha = 1;
+
+  drawNameplate(context, speakerName, panelX + 86, panelY + 32);
+  drawActionCapsules(context, actions, panelX + panelW - 86, panelY + 45);
+  context.restore();
+}
+
+function drawNameplate(
+  context: CanvasRenderingContext2D,
+  speakerName: string,
+  x: number,
+  y: number
+): void {
+  context.font = NAME_FONT;
+  const width = Math.max(154, context.measureText(speakerName).width + 82);
+  const height = 42;
+
+  context.save();
+  const gradient = context.createLinearGradient(0, y, 0, y + height);
+  gradient.addColorStop(0, '#1d255f');
+  gradient.addColorStop(1, '#070a22');
+  roundedRectPath(context, x, y, width, height, 10);
+  context.fillStyle = gradient;
+  context.fill();
+  context.lineWidth = 5;
+  context.strokeStyle = '#fffaf0';
+  context.stroke();
+  context.lineWidth = 2;
+  context.strokeStyle = '#9aa4ff';
+  roundedRectPath(context, x + 7, y + 7, width - 14, height - 14, 6);
+  context.stroke();
+
+  context.textBaseline = 'middle';
+  context.fillStyle = '#fff9e8';
+  context.shadowColor = 'rgba(0, 0, 0, 0.72)';
+  context.shadowBlur = 4;
+  context.fillText(speakerName, x + 28, y + height / 2 + 1);
+  context.restore();
+}
+
+function drawActionCapsules(
+  context: CanvasRenderingContext2D,
+  actions: readonly SpeechBubbleAction[],
+  rightX: number,
+  y: number
+): void {
+  if (actions.length === 0) {
+    return;
+  }
+
+  context.save();
+  context.font = ACTION_FONT;
+  context.textBaseline = 'middle';
+  let x = rightX;
+  const visibleActions = actions.slice(-3).reverse();
+  visibleActions.forEach((action) => {
+    const label = formatActionLabel(action.label);
+    const width = Math.min(260, Math.max(96, context.measureText(label).width + 42));
+    x -= width;
+    const gradient = context.createLinearGradient(0, y, 0, y + 34);
+    gradient.addColorStop(0, 'rgba(105, 255, 222, 0.34)');
+    gradient.addColorStop(1, 'rgba(113, 90, 255, 0.24)');
+    roundedRectPath(context, x, y, width, 34, 17);
+    context.fillStyle = gradient;
+    context.fill();
+    context.lineWidth = 2;
+    context.strokeStyle = 'rgba(255, 255, 255, 0.82)';
+    context.stroke();
+    context.fillStyle = '#eafff9';
+    context.shadowColor = 'rgba(0, 0, 0, 0.55)';
+    context.shadowBlur = 3;
+    context.fillText(label, x + 21, y + 18);
+    context.shadowBlur = 0;
+    x -= 12;
+  });
+  context.restore();
+}
+
+function formatActionLabel(label: string): string {
+  return label.replace(/_/g, ' ').replace(/\b\w/g, (match) => match.toUpperCase());
+}
+
+function sameActions(
+  current: readonly SpeechBubbleAction[],
+  next: readonly SpeechBubbleAction[]
+): boolean {
+  if (current.length !== next.length) {
+    return false;
+  }
+  return current.every((action, index) => {
+    const nextAction = next[index];
+    return nextAction?.id === action.id && nextAction.label === action.label;
+  });
+}
+
+function roundedRectPath(
+  context: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+  radius: number
+): void {
+  const safeRadius = Math.min(radius, width / 2, height / 2);
+  context.beginPath();
+  context.moveTo(x + safeRadius, y);
+  context.lineTo(x + width - safeRadius, y);
+  context.quadraticCurveTo(x + width, y, x + width, y + safeRadius);
+  context.lineTo(x + width, y + height - safeRadius);
+  context.quadraticCurveTo(x + width, y + height, x + width - safeRadius, y + height);
+  context.lineTo(x + safeRadius, y + height);
+  context.quadraticCurveTo(x, y + height, x, y + height - safeRadius);
+  context.lineTo(x, y + safeRadius);
+  context.quadraticCurveTo(x, y, x + safeRadius, y);
+  context.closePath();
 }
 
 function wrapText(
@@ -429,4 +479,8 @@ function appendEllipsis(lines: string[]): string[] {
   const lastLine = result[result.length - 1] ?? '';
   result[result.length - 1] = `${lastLine.replace(/[\s.]+$/u, '')}...`;
   return result;
+}
+
+function easeOutCubic(t: number): number {
+  return 1 - Math.pow(1 - t, 3);
 }

--- a/apps/avatar/src/scene/speech-bubble.ts
+++ b/apps/avatar/src/scene/speech-bubble.ts
@@ -2,9 +2,9 @@
 //
 // speech-bubble.ts
 //
-// - Renders an opaque JRPG-style dialogue window near the avatar.
-// - The full panel is drawn into one CanvasTexture so the border, fill,
-//   nameplate, tail, and text stay visually cohesive.
+// - Renders a soft fantasy dialogue window near the avatar.
+// - The full panel is drawn into one CanvasTexture so the fill, nameplate,
+//   action chips, and text stay visually cohesive.
 //
 //////////////////////////////////////////////////////////////////////////////
 
@@ -172,9 +172,9 @@ export class SpeechBubble {
 
     context.font = TEXT_FONT;
     context.textBaseline = 'alphabetic';
-    context.fillStyle = '#fff9e8';
-    context.shadowColor = 'rgba(0, 0, 0, 0.82)';
-    context.shadowBlur = 5;
+    context.fillStyle = '#fff6df';
+    context.shadowColor = 'rgba(3, 2, 12, 0.82)';
+    context.shadowBlur = 4;
     context.shadowOffsetX = 2;
     context.shadowOffsetY = 3;
 
@@ -225,52 +225,84 @@ function drawDialogueWindow(
   const panelX = 68;
   const panelY = 74;
   const panelW = 1264;
-  const panelH = 270;
-  const tailX = 275;
-  const tailTopY = panelY + panelH - 4;
+  const panelH = 300;
+  const wedgeX = panelX + panelW * 0.26;
+  const wedgeBaseY = panelY + panelH - 8;
+  const wedgeTipY = CANVAS_HEIGHT - 12;
 
   context.save();
-  context.shadowColor = 'rgba(0, 0, 0, 0.48)';
-  context.shadowBlur = 22;
-  context.shadowOffsetY = 12;
+  context.shadowColor = 'rgba(3, 2, 12, 0.7)';
+  context.shadowBlur = 34;
+  context.shadowOffsetY = 14;
 
   context.beginPath();
-  roundedRectPath(context, panelX, panelY, panelW, panelH, 16);
-  context.moveTo(tailX, tailTopY);
-  context.lineTo(tailX + 72, tailTopY);
-  context.lineTo(tailX + 26, tailTopY + 72);
+  roundedRectPath(context, panelX, panelY, panelW, panelH, 26);
+  context.moveTo(wedgeX - 54, wedgeBaseY);
+  context.lineTo(wedgeX + 54, wedgeBaseY);
+  context.lineTo(wedgeX - 12, wedgeTipY);
   context.closePath();
-  context.fillStyle = '#050717';
+  const shellGradient = context.createLinearGradient(panelX, panelY, panelX + panelW, panelY + panelH);
+  shellGradient.addColorStop(0, 'rgba(26, 17, 42, 0.96)');
+  shellGradient.addColorStop(0.58, 'rgba(14, 10, 30, 0.98)');
+  shellGradient.addColorStop(1, 'rgba(30, 17, 47, 0.96)');
+  context.fillStyle = shellGradient;
   context.fill();
 
-  const fillGradient = context.createLinearGradient(0, panelY, 0, panelY + panelH);
-  fillGradient.addColorStop(0, '#171d4b');
-  fillGradient.addColorStop(0.5, '#0e1330');
-  fillGradient.addColorStop(1, '#06091d');
-  context.shadowBlur = 0;
-  context.fillStyle = fillGradient;
-  context.fill();
+  // const fillGradient = context.createRadialGradient(
+  //   panelX + panelW * 0.2,
+  //   panelY,
+  //   40,
+  //   panelX + panelW * 0.42,
+  //   panelY + panelH * 0.34,
+  //   panelW * 0.72
+  // );
+  // fillGradient.addColorStop(0, 'rgba(255, 218, 143, 0.1)');
+  // fillGradient.addColorStop(0.34, 'rgba(28, 18, 49, 0.9)');
+  // fillGradient.addColorStop(1, 'rgba(8, 6, 20, 0.98)');
+  // context.shadowBlur = 0;
+  // context.fillStyle = fillGradient;
+  // context.fill();
 
-  context.lineJoin = 'round';
-  context.lineWidth = 2;
-  context.strokeStyle = 'rgba(255, 255, 255, 0.22)';
-  context.stroke();
-  context.lineWidth = 6;
-  context.strokeStyle = '#fffaf0';
-  context.stroke();
-  context.lineWidth = 4;
-  context.strokeStyle = '#97a0ff';
-  context.stroke();
+  // context.globalCompositeOperation = 'screen';
+  // const warmGlow = context.createRadialGradient(
+  //   panelX + panelW * 0.16,
+  //   panelY + panelH * 0.04,
+  //   0,
+  //   panelX + panelW * 0.16,
+  //   panelY + panelH * 0.04,
+  //   panelW * 0.38
+  // );
+  // warmGlow.addColorStop(0, 'rgba(255, 218, 143, 0.16)');
+  // warmGlow.addColorStop(1, 'rgba(255, 218, 143, 0)');
+  // context.fillStyle = warmGlow;
+  // context.fill();
 
-  context.globalAlpha = 0.5;
+  // const violetGlow = context.createRadialGradient(
+  //   panelX + panelW * 0.8,
+  //   panelY + panelH * 0.86,
+  //   0,
+  //   panelX + panelW * 0.8,
+  //   panelY + panelH * 0.86,
+  //   panelW * 0.4
+  // );
+  // violetGlow.addColorStop(0, 'rgba(151, 105, 255, 0.16)');
+  // violetGlow.addColorStop(1, 'rgba(151, 105, 255, 0)');
+  // context.fillStyle = violetGlow;
+  // context.fill();
+  // context.globalCompositeOperation = 'source-over';
+
+  context.globalAlpha = 0.1;
   context.beginPath();
-  roundedRectPath(context, panelX + 38, panelY + 38, panelW - 76, panelH - 76, 9);
-  context.strokeStyle = '#dfe4ff';
-  context.lineWidth = 3;
-  context.stroke();
+  roundedRectPath(context, panelX + 26, panelY + 24, panelW - 52, panelH - 48, 22);
+  const innerSheen = context.createLinearGradient(panelX, panelY, panelX + panelW, panelY + panelH);
+  innerSheen.addColorStop(0, 'rgba(255, 238, 190, 0.18)');
+  innerSheen.addColorStop(0.52, 'rgba(151, 105, 255, 0.08)');
+  innerSheen.addColorStop(1, 'rgba(82, 255, 211, 0.08)');
+  context.fillStyle = innerSheen;
+  context.fill();
   context.globalAlpha = 1;
 
-  drawNameplate(context, speakerName, panelX + 86, panelY + 32);
+  drawNameplate(context, speakerName, panelX + 86, panelY + 34);
   drawActionCapsules(context, actions, panelX + panelW - 86, panelY + 45);
   context.restore();
 }
@@ -282,29 +314,25 @@ function drawNameplate(
   y: number
 ): void {
   context.font = NAME_FONT;
-  const width = Math.max(154, context.measureText(speakerName).width + 82);
-  const height = 42;
+  const width = Math.max(150, context.measureText(speakerName).width + 76);
+  const height = 40;
 
   context.save();
-  const gradient = context.createLinearGradient(0, y, 0, y + height);
-  gradient.addColorStop(0, '#1d255f');
-  gradient.addColorStop(1, '#070a22');
-  roundedRectPath(context, x, y, width, height, 10);
+  context.shadowColor = 'rgba(3, 2, 12, 0.38)';
+  context.shadowBlur = 12;
+  const gradient = context.createLinearGradient(x, y, x + width, y + height);
+  gradient.addColorStop(0, 'rgba(255, 218, 143, 0.2)');
+  gradient.addColorStop(0.5, 'rgba(151, 105, 255, 0.2)');
+  gradient.addColorStop(1, 'rgba(82, 255, 211, 0.12)');
+  roundedRectPath(context, x, y, width, height, 14);
   context.fillStyle = gradient;
   context.fill();
-  context.lineWidth = 5;
-  context.strokeStyle = '#fffaf0';
-  context.stroke();
-  context.lineWidth = 2;
-  context.strokeStyle = '#9aa4ff';
-  roundedRectPath(context, x + 7, y + 7, width - 14, height - 14, 6);
-  context.stroke();
 
   context.textBaseline = 'middle';
-  context.fillStyle = '#fff9e8';
+  context.fillStyle = '#fff6df';
   context.shadowColor = 'rgba(0, 0, 0, 0.72)';
   context.shadowBlur = 4;
-  context.fillText(speakerName, x + 28, y + height / 2 + 1);
+  context.fillText(speakerName, x + 26, y + height / 2 + 1);
   context.restore();
 }
 
@@ -327,16 +355,15 @@ function drawActionCapsules(
     const label = formatActionLabel(action.label);
     const width = Math.min(260, Math.max(96, context.measureText(label).width + 42));
     x -= width;
-    const gradient = context.createLinearGradient(0, y, 0, y + 34);
-    gradient.addColorStop(0, 'rgba(105, 255, 222, 0.34)');
-    gradient.addColorStop(1, 'rgba(113, 90, 255, 0.24)');
+    const gradient = context.createLinearGradient(x, y, x + width, y + 34);
+    gradient.addColorStop(0, 'rgba(82, 255, 211, 0.2)');
+    gradient.addColorStop(1, 'rgba(151, 105, 255, 0.18)');
     roundedRectPath(context, x, y, width, 34, 17);
+    context.shadowColor = 'rgba(3, 2, 12, 0.3)';
+    context.shadowBlur = 8;
     context.fillStyle = gradient;
     context.fill();
-    context.lineWidth = 2;
-    context.strokeStyle = 'rgba(255, 255, 255, 0.82)';
-    context.stroke();
-    context.fillStyle = '#eafff9';
+    context.fillStyle = '#c4fff4';
     context.shadowColor = 'rgba(0, 0, 0, 0.55)';
     context.shadowBlur = 3;
     context.fillText(label, x + 21, y + 18);

--- a/apps/avatar/src/scene/world-effects.ts
+++ b/apps/avatar/src/scene/world-effects.ts
@@ -1,0 +1,406 @@
+//////////////////////////////////////////////////////////////////////////////
+//
+// world-effects.ts
+//
+// - Small procedural fantasy effects used by avatar actions. These are
+//   intentionally asset-free so the demo stays portable.
+//
+//////////////////////////////////////////////////////////////////////////////
+
+import * as THREE from 'three';
+import { VRMHumanBoneName } from '@pixiv/three-vrm';
+import type { WorldEffectActionName } from '../actions/world-effects';
+import type { LoadedAvatar } from './vrm-loader';
+
+interface TimedEffect {
+  readonly root: THREE.Object3D;
+  readonly durationSeconds: number;
+  ageSeconds: number;
+  update(deltaSeconds: number, ageRatio: number): void;
+}
+
+const STAR_GOLD = new THREE.Color('#ffd98a');
+const RUNE_BLUE = new THREE.Color('#7ddfff');
+const WARD_VIOLET = new THREE.Color('#b48cff');
+const FAMILIAR_TEAL = new THREE.Color('#69ffd6');
+
+export class FantasyWorldEffects {
+  private readonly scene: THREE.Scene;
+  private readonly avatar: LoadedAvatar;
+  private readonly effects: TimedEffect[] = [];
+  private readonly tmpVec = new THREE.Vector3();
+  private readonly tmpVec2 = new THREE.Vector3();
+
+  public constructor(scene: THREE.Scene, avatar: LoadedAvatar) {
+    this.scene = scene;
+    this.avatar = avatar;
+  }
+
+  public trigger(name: WorldEffectActionName): void {
+    switch (name) {
+      case 'summon_familiar':
+        this.addEffect(this.createFamiliarEffect());
+        return;
+      case 'cast_starbolt':
+        this.addEffect(this.createStarboltEffect());
+        return;
+      case 'raise_ward':
+        this.addEffect(this.createWardEffect());
+        return;
+      case 'summon_rune_circle':
+        this.addEffect(this.createRuneCircleEffect());
+        return;
+    }
+  }
+
+  public tick(deltaSeconds: number): void {
+    for (let index = this.effects.length - 1; index >= 0; index -= 1) {
+      const effect = this.effects[index];
+      effect.ageSeconds += deltaSeconds;
+      const ageRatio = THREE.MathUtils.clamp(effect.ageSeconds / effect.durationSeconds, 0, 1);
+      effect.update(deltaSeconds, ageRatio);
+      if (effect.ageSeconds >= effect.durationSeconds) {
+        this.scene.remove(effect.root);
+        disposeObject(effect.root);
+        this.effects.splice(index, 1);
+      }
+    }
+  }
+
+  public dispose(): void {
+    for (const effect of this.effects) {
+      this.scene.remove(effect.root);
+      disposeObject(effect.root);
+    }
+    this.effects.length = 0;
+  }
+
+  private addEffect(effect: TimedEffect): void {
+    this.effects.push(effect);
+    this.scene.add(effect.root);
+  }
+
+  private createFamiliarEffect(): TimedEffect {
+    const root = new THREE.Group();
+    const core = new THREE.Mesh(
+      new THREE.SphereGeometry(0.075, 24, 16),
+      new THREE.MeshBasicMaterial({
+        color: FAMILIAR_TEAL,
+        transparent: true,
+        opacity: 0.9,
+        blending: THREE.AdditiveBlending,
+      })
+    );
+    const aura = new THREE.Mesh(
+      new THREE.SphereGeometry(0.18, 24, 16),
+      new THREE.MeshBasicMaterial({
+        color: FAMILIAR_TEAL,
+        transparent: true,
+        opacity: 0.18,
+        blending: THREE.AdditiveBlending,
+        depthWrite: false,
+      })
+    );
+    const wingMaterial = new THREE.MeshBasicMaterial({
+      color: '#d8fff4',
+      transparent: true,
+      opacity: 0.34,
+      blending: THREE.AdditiveBlending,
+      side: THREE.DoubleSide,
+      depthWrite: false,
+    });
+    const leftWing = new THREE.Mesh(new THREE.CircleGeometry(0.11, 18), wingMaterial);
+    const rightWing = new THREE.Mesh(new THREE.CircleGeometry(0.11, 18), wingMaterial.clone());
+    leftWing.scale.set(1.4, 0.52, 1);
+    rightWing.scale.set(1.4, 0.52, 1);
+    root.add(aura, core, leftWing, rightWing);
+
+    return {
+      root,
+      durationSeconds: 8,
+      ageSeconds: 0,
+      update: (_deltaSeconds, ageRatio) => {
+        const anchor = this.getAvatarAnchor(0.48, 0.78, 0.06, this.tmpVec);
+        const orbit = ageRatio * Math.PI * 7;
+        root.position.set(
+          anchor.x + Math.cos(orbit) * 0.34,
+          anchor.y + Math.sin(orbit * 1.7) * 0.055,
+          anchor.z + Math.sin(orbit) * 0.2
+        );
+        const pulse = 0.9 + Math.sin(ageRatio * Math.PI * 34) * 0.12;
+        core.scale.setScalar(pulse);
+        aura.scale.setScalar(0.95 + Math.sin(ageRatio * Math.PI * 16) * 0.1);
+        leftWing.position.set(-0.11, 0.025, 0.012);
+        rightWing.position.set(0.11, 0.025, 0.012);
+        leftWing.rotation.set(0.35, Math.sin(ageRatio * Math.PI * 32) * 0.6, 0.2);
+        rightWing.rotation.set(0.35, -Math.sin(ageRatio * Math.PI * 32) * 0.6, -0.2);
+        const fade = fadeInOut(ageRatio, 0.12, 0.18);
+        setOpacity(core, 0.9 * fade);
+        setOpacity(aura, 0.18 * fade);
+        setOpacity(leftWing, 0.34 * fade);
+        setOpacity(rightWing, 0.34 * fade);
+      },
+    };
+  }
+
+  private createStarboltEffect(): TimedEffect {
+    const root = new THREE.Group();
+    const bolt = new THREE.Mesh(
+      new THREE.SphereGeometry(0.08, 24, 16),
+      new THREE.MeshBasicMaterial({
+        color: STAR_GOLD,
+        transparent: true,
+        opacity: 0.96,
+        blending: THREE.AdditiveBlending,
+      })
+    );
+    const halo = new THREE.Mesh(
+      new THREE.SphereGeometry(0.2, 24, 16),
+      new THREE.MeshBasicMaterial({
+        color: STAR_GOLD,
+        transparent: true,
+        opacity: 0.2,
+        blending: THREE.AdditiveBlending,
+        depthWrite: false,
+      })
+    );
+    const trail = new THREE.Mesh(
+      new THREE.CylinderGeometry(0.022, 0.09, 0.75, 18, 1, true),
+      new THREE.MeshBasicMaterial({
+        color: '#fff3bc',
+        transparent: true,
+        opacity: 0.24,
+        blending: THREE.AdditiveBlending,
+        side: THREE.DoubleSide,
+        depthWrite: false,
+      })
+    );
+    trail.rotation.x = Math.PI / 2;
+    trail.position.z = -0.34;
+    root.add(trail, halo, bolt);
+
+    const origin = this.getRightHandAnchor(this.tmpVec).clone();
+    const destination = origin.clone().add(new THREE.Vector3(0.04, 0.08, 2.6));
+
+    return {
+      root,
+      durationSeconds: 1.15,
+      ageSeconds: 0,
+      update: (_deltaSeconds, ageRatio) => {
+        root.position.copy(origin).lerp(destination, easeOutCubic(ageRatio));
+        root.rotation.z += 0.24;
+        const burst = ageRatio > 0.78 ? 1 + (ageRatio - 0.78) * 9 : 1;
+        bolt.scale.setScalar(burst);
+        halo.scale.setScalar(1.1 + burst * 0.7);
+        const fade = fadeInOut(ageRatio, 0.05, 0.24);
+        setOpacity(bolt, 0.96 * fade);
+        setOpacity(halo, 0.22 * fade);
+        setOpacity(trail, 0.24 * fade * (1 - ageRatio * 0.6));
+      },
+    };
+  }
+
+  private createWardEffect(): TimedEffect {
+    const root = new THREE.Group();
+    const disc = new THREE.Mesh(
+      new THREE.CircleGeometry(0.52, 64),
+      new THREE.MeshBasicMaterial({
+        color: WARD_VIOLET,
+        transparent: true,
+        opacity: 0.16,
+        blending: THREE.AdditiveBlending,
+        side: THREE.DoubleSide,
+        depthWrite: false,
+      })
+    );
+    const outer = new THREE.Mesh(
+      new THREE.TorusGeometry(0.52, 0.012, 12, 80),
+      new THREE.MeshBasicMaterial({
+        color: '#d7c5ff',
+        transparent: true,
+        opacity: 0.84,
+        blending: THREE.AdditiveBlending,
+        depthWrite: false,
+      })
+    );
+    const inner = new THREE.Mesh(
+      new THREE.TorusGeometry(0.34, 0.007, 10, 64),
+      (outer.material as THREE.MeshBasicMaterial).clone()
+    );
+    const spokes = createRadialMarks(10, 0.43, 0.1, '#efe7ff');
+    root.add(disc, outer, inner, spokes);
+    storeBaseOpacity(root);
+
+    return {
+      root,
+      durationSeconds: 2.6,
+      ageSeconds: 0,
+      update: (_deltaSeconds, ageRatio) => {
+        const anchor = this.getAvatarAnchor(0, 0.52, 0.86, this.tmpVec);
+        root.position.copy(anchor);
+        root.rotation.set(0, 0, ageRatio * Math.PI * 1.8);
+        const scale = 0.2 + easeOutCubic(Math.min(ageRatio / 0.24, 1)) * 0.95;
+        root.scale.setScalar(scale);
+        const fade = fadeInOut(ageRatio, 0.08, 0.34);
+        root.traverse((object) => {
+          if (object instanceof THREE.Mesh) {
+            const material = object.material as THREE.MeshBasicMaterial;
+            material.opacity = material.userData.baseOpacity * fade;
+          }
+        });
+      },
+    };
+  }
+
+  private createRuneCircleEffect(): TimedEffect {
+    const root = new THREE.Group();
+    root.rotation.x = -Math.PI / 2;
+    const outer = new THREE.Mesh(
+      new THREE.TorusGeometry(0.9, 0.01, 10, 96),
+      new THREE.MeshBasicMaterial({
+        color: RUNE_BLUE,
+        transparent: true,
+        opacity: 0.75,
+        blending: THREE.AdditiveBlending,
+        depthWrite: false,
+      })
+    );
+    const inner = new THREE.Mesh(
+      new THREE.TorusGeometry(0.62, 0.007, 10, 80),
+      (outer.material as THREE.MeshBasicMaterial).clone()
+    );
+    const center = new THREE.Mesh(
+      new THREE.CircleGeometry(0.42, 64),
+      new THREE.MeshBasicMaterial({
+        color: '#8fffe8',
+        transparent: true,
+        opacity: 0.12,
+        blending: THREE.AdditiveBlending,
+        side: THREE.DoubleSide,
+        depthWrite: false,
+      })
+    );
+    const marks = createRadialMarks(18, 0.76, 0.07, '#c8fff8');
+    root.add(center, outer, inner, marks);
+    storeBaseOpacity(root);
+
+    return {
+      root,
+      durationSeconds: 3.2,
+      ageSeconds: 0,
+      update: (_deltaSeconds, ageRatio) => {
+        const anchor = this.getAvatarAnchor(0, 0.012, 0, this.tmpVec);
+        root.position.copy(anchor);
+        root.rotation.z = ageRatio * Math.PI * 2.2;
+        const pulse = 0.82 + Math.sin(ageRatio * Math.PI * 7) * 0.08;
+        root.scale.setScalar(pulse);
+        const fade = fadeInOut(ageRatio, 0.1, 0.22);
+        root.traverse((object) => {
+          if (object instanceof THREE.Mesh) {
+            const material = object.material as THREE.MeshBasicMaterial;
+            material.opacity = material.userData.baseOpacity * fade;
+          }
+        });
+      },
+    };
+  }
+
+  private getRightHandAnchor(target: THREE.Vector3): THREE.Vector3 {
+    const hand = this.avatar.vrm.humanoid?.getNormalizedBoneNode(VRMHumanBoneName.RightHand);
+    if (hand) {
+      hand.getWorldPosition(target);
+      return target;
+    }
+    return this.getAvatarAnchor(0.24, 0.64, 0.24, target);
+  }
+
+  private getAvatarAnchor(xRatio: number, yRatio: number, zOffset: number, target: THREE.Vector3): THREE.Vector3 {
+    this.avatar.root.getWorldPosition(target);
+    this.avatar.root.getWorldScale(this.tmpVec2);
+    target.x += this.avatar.layout.height * xRatio * this.tmpVec2.x;
+    target.y += this.avatar.layout.height * yRatio * this.tmpVec2.y;
+    target.z += zOffset;
+    return target;
+  }
+}
+
+function createRadialMarks(count: number, radius: number, length: number, color: string): THREE.Group {
+  const group = new THREE.Group();
+  const geometry = new THREE.BoxGeometry(0.018, length, 0.008);
+  for (let index = 0; index < count; index += 1) {
+    const angle = (index / count) * Math.PI * 2;
+    const mark = new THREE.Mesh(
+      geometry,
+      new THREE.MeshBasicMaterial({
+        color,
+        transparent: true,
+        opacity: 0.62,
+        blending: THREE.AdditiveBlending,
+        depthWrite: false,
+      })
+    );
+    mark.position.set(Math.cos(angle) * radius, Math.sin(angle) * radius, 0.006);
+    mark.rotation.z = angle;
+    group.add(mark);
+  }
+  return group;
+}
+
+function fadeInOut(ageRatio: number, fadeIn: number, fadeOut: number): number {
+  const intro = THREE.MathUtils.clamp(ageRatio / fadeIn, 0, 1);
+  const outro = THREE.MathUtils.clamp((1 - ageRatio) / fadeOut, 0, 1);
+  return easeOutCubic(Math.min(intro, outro));
+}
+
+function setOpacity(mesh: THREE.Mesh, opacity: number): void {
+  const material = mesh.material;
+  if (Array.isArray(material)) {
+    material.forEach((entry) => {
+      if ('opacity' in entry) {
+        entry.opacity = opacity;
+      }
+    });
+    return;
+  }
+  material.opacity = opacity;
+}
+
+function disposeObject(root: THREE.Object3D): void {
+  const disposedGeometries = new Set<THREE.BufferGeometry>();
+  const disposedMaterials = new Set<THREE.Material>();
+  root.traverse((object) => {
+    const mesh = object as THREE.Mesh;
+    if (mesh.geometry && !disposedGeometries.has(mesh.geometry)) {
+      disposedGeometries.add(mesh.geometry);
+      mesh.geometry.dispose();
+    }
+    const material = mesh.material;
+    if (Array.isArray(material)) {
+      material.forEach((entry) => {
+        if (!disposedMaterials.has(entry)) {
+          disposedMaterials.add(entry);
+          entry.dispose();
+        }
+      });
+    } else if (material && !disposedMaterials.has(material)) {
+      disposedMaterials.add(material);
+      material.dispose();
+    }
+  });
+}
+
+function storeBaseOpacity(root: THREE.Object3D): void {
+  root.traverse((object) => {
+    if (!(object instanceof THREE.Mesh)) {
+      return;
+    }
+    const materials = Array.isArray(object.material) ? object.material : [object.material];
+    materials.forEach((material) => {
+      material.userData.baseOpacity = material.opacity;
+    });
+  });
+}
+
+function easeOutCubic(t: number): number {
+  return 1 - Math.pow(1 - t, 3);
+}

--- a/apps/avatar/src/style.css
+++ b/apps/avatar/src/style.css
@@ -377,7 +377,7 @@ textarea:focus {
 .start-button {
   width:100%;
   justify-self: center;
-  border-radius: 999px;
+  border-radius: 24px;
   padding: 16px 28px;
   font-size: 18px;
   letter-spacing: 0.14em;

--- a/apps/avatar/src/style.css
+++ b/apps/avatar/src/style.css
@@ -68,6 +68,7 @@ textarea {
 
 button {
   border: 0;
+  margin: auto;
   border-radius: 18px;
   padding: 12px 16px;
   font-weight: 700;

--- a/apps/avatar/src/style.css
+++ b/apps/avatar/src/style.css
@@ -1,16 +1,51 @@
 :root {
   color-scheme: dark;
   font-family: 'Trebuchet MS', 'Segoe UI', sans-serif;
-  color: #ecf5ff;
+  color: #fff6df;
   background:
-    radial-gradient(circle at 18% 16%, rgba(129, 176, 255, 0.2), transparent 24%),
-    radial-gradient(circle at 82% 22%, rgba(189, 139, 255, 0.16), transparent 26%),
-    radial-gradient(circle at 50% 92%, rgba(91, 220, 191, 0.18), transparent 30%),
-    linear-gradient(180deg, #07101f 0%, #0b1020 42%, #090b16 100%);
+    radial-gradient(circle at 20% 12%, rgba(255, 217, 138, 0.18), transparent 22%),
+    radial-gradient(circle at 78% 18%, rgba(151, 105, 255, 0.22), transparent 26%),
+    radial-gradient(circle at 50% 88%, rgba(82, 255, 211, 0.16), transparent 32%),
+    linear-gradient(180deg, #090716 0%, #120b25 42%, #070611 100%);
 }
 
 * {
   box-sizing: border-box;
+}
+
+* {
+  scrollbar-width: thin;
+  scrollbar-color: transparent transparent;
+}
+
+*:hover,
+*:focus-within {
+  scrollbar-color: rgba(255, 248, 232, 0.42) transparent;
+}
+
+*::-webkit-scrollbar {
+  width: 7px;
+  height: 7px;
+}
+
+*::-webkit-scrollbar-track,
+*::-webkit-scrollbar-corner {
+  background: transparent;
+}
+
+*::-webkit-scrollbar-thumb {
+  border-radius: 999px;
+  background: transparent;
+}
+
+*:hover::-webkit-scrollbar-thumb,
+*:focus-within::-webkit-scrollbar-thumb {
+  background: rgba(255, 248, 232, 0.42);
+}
+
+*:hover::-webkit-scrollbar-thumb:hover,
+*:focus-within::-webkit-scrollbar-thumb:hover {
+  background: rgba(255, 248, 232, 0.62);
 }
 
 html,
@@ -21,7 +56,7 @@ body,
 
 body {
   margin: 0;
-  color: #ecf5ff;
+  color: #fff6df;
   background: transparent;
 }
 
@@ -36,24 +71,25 @@ button {
   border-radius: 18px;
   padding: 12px 16px;
   font-weight: 700;
-  color: #f9fbff;
-  background: linear-gradient(135deg, #60b5ff, #6a7cff 52%, #a177ff 100%);
+  color: #24150a;
+  background: linear-gradient(135deg, #ffe19a, #ffb347 48%, #d884ff 100%);
   box-shadow:
-    inset 0 1px 0 rgba(255, 255, 255, 0.24),
-    0 16px 30px rgba(24, 34, 78, 0.28);
+    inset 0 1px 0 rgba(255, 255, 255, 0.42),
+    0 16px 30px rgba(20, 9, 38, 0.34);
   cursor: pointer;
   transition:
     transform 140ms ease,
     box-shadow 140ms ease,
     opacity 140ms ease,
-    background-color 140ms ease;
+    background-color 140ms ease,
+    border-color 140ms ease;
 }
 
 button:hover:not(:disabled) {
   transform: translateY(-1px);
   box-shadow:
-    inset 0 1px 0 rgba(255, 255, 255, 0.28),
-    0 18px 34px rgba(28, 40, 95, 0.32);
+    inset 0 1px 0 rgba(255, 255, 255, 0.5),
+    0 18px 34px rgba(60, 29, 89, 0.38);
 }
 
 button:disabled {
@@ -66,11 +102,11 @@ button:disabled {
 input,
 textarea {
   width: 100%;
-  border: 1px solid rgba(180, 216, 255, 0.14);
+  border: 1px solid rgba(255, 221, 158, 0.18);
   border-radius: 18px;
   padding: 13px 16px;
-  color: #eff7ff;
-  background: rgba(7, 15, 29, 0.62);
+  color: #fff8e8;
+  background: rgba(13, 9, 25, 0.72);
   outline: none;
   transition:
     border-color 140ms ease,
@@ -80,9 +116,9 @@ textarea {
 
 input:focus,
 textarea:focus {
-  border-color: rgba(151, 214, 255, 0.5);
-  background: rgba(11, 20, 38, 0.84);
-  box-shadow: 0 0 0 4px rgba(118, 182, 255, 0.12);
+  border-color: rgba(255, 221, 146, 0.55);
+  background: rgba(20, 13, 35, 0.88);
+  box-shadow: 0 0 0 4px rgba(255, 202, 109, 0.13);
 }
 
 #app {
@@ -101,8 +137,10 @@ textarea:focus {
   inset: 18px;
   border-radius: 34px;
   pointer-events: none;
-  border: 1px solid rgba(180, 216, 255, 0.08);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 216, 143, 0.1);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.08),
+    0 0 80px rgba(114, 84, 255, 0.1);
 }
 
 .stage-shell {
@@ -112,11 +150,12 @@ textarea:focus {
   overflow: hidden;
   border-radius: 34px;
   background:
-    radial-gradient(circle at 50% 24%, rgba(133, 176, 255, 0.18), transparent 30%),
-    radial-gradient(circle at 50% 88%, rgba(111, 255, 213, 0.08), transparent 24%),
-    linear-gradient(180deg, rgba(5, 10, 18, 0.34), rgba(8, 14, 24, 0.16));
+    radial-gradient(circle at 50% 18%, rgba(255, 241, 191, 0.12), transparent 16%),
+    radial-gradient(circle at 48% 28%, rgba(130, 94, 255, 0.22), transparent 31%),
+    radial-gradient(circle at 50% 90%, rgba(79, 255, 215, 0.12), transparent 26%),
+    linear-gradient(180deg, rgba(8, 6, 18, 0.38), rgba(12, 8, 24, 0.18));
   box-shadow:
-    0 24px 64px rgba(3, 7, 19, 0.42),
+    0 24px 64px rgba(3, 2, 12, 0.54),
     inset 0 1px 0 rgba(255, 255, 255, 0.04);
 }
 
@@ -124,9 +163,10 @@ textarea:focus {
   position: absolute;
   inset: 0;
   background:
-    radial-gradient(circle at 50% 28%, rgba(152, 203, 255, 0.17) 0%, rgba(93, 115, 204, 0.08) 26%, transparent 50%),
-    radial-gradient(circle at 50% 82%, rgba(106, 255, 209, 0.08), transparent 28%),
-    linear-gradient(180deg, rgba(12, 20, 38, 0.88) 0%, rgba(9, 15, 27, 0.96) 100%);
+    radial-gradient(circle at 50% 9%, rgba(255, 235, 180, 0.18) 0%, transparent 12%),
+    radial-gradient(circle at 48% 30%, rgba(135, 103, 255, 0.24) 0%, rgba(47, 36, 96, 0.12) 30%, transparent 54%),
+    radial-gradient(circle at 50% 84%, rgba(91, 255, 218, 0.14), transparent 30%),
+    linear-gradient(180deg, rgba(13, 9, 32, 0.94) 0%, rgba(8, 7, 19, 0.98) 100%);
   overflow: hidden;
 }
 
@@ -145,7 +185,7 @@ textarea:focus {
   height: 180px;
   transform: translateX(-50%);
   border-radius: 50%;
-  background: radial-gradient(circle, rgba(103, 236, 206, 0.14) 0%, rgba(44, 90, 150, 0.05) 42%, transparent 72%);
+  background: radial-gradient(circle, rgba(105, 255, 220, 0.18) 0%, rgba(107, 61, 215, 0.06) 42%, transparent 72%);
   filter: blur(24px);
 }
 
@@ -155,7 +195,7 @@ textarea:focus {
   width: 180px;
   height: 180px;
   border-radius: 999px;
-  background: radial-gradient(circle, rgba(205, 184, 255, 0.18), transparent 72%);
+  background: radial-gradient(circle, rgba(255, 226, 153, 0.2), transparent 72%);
   filter: blur(30px);
 }
 
@@ -181,6 +221,12 @@ textarea:focus {
   right: 22px;
 }
 
+.stage-actions {
+  left: 22px;
+  top: 386px;
+  width: min(380px, calc(100% - 44px));
+}
+
 .stage-bottom {
   left: 22px;
   right: 22px;
@@ -195,10 +241,12 @@ textarea:focus {
 }
 
 .glass-panel {
-  border: 1px solid rgba(176, 216, 255, 0.14);
-  background: linear-gradient(180deg, rgba(13, 22, 40, 0.76), rgba(9, 16, 30, 0.78));
+  border: 1px solid rgba(255, 218, 149, 0.16);
+  background:
+    linear-gradient(180deg, rgba(26, 17, 42, 0.82), rgba(13, 9, 28, 0.82)),
+    radial-gradient(circle at 18% 0%, rgba(255, 218, 143, 0.08), transparent 28%);
   box-shadow:
-    0 18px 44px rgba(5, 11, 24, 0.35),
+    0 18px 44px rgba(3, 2, 12, 0.48),
     inset 0 1px 0 rgba(255, 255, 255, 0.08);
   backdrop-filter: blur(20px);
 }
@@ -208,7 +256,132 @@ textarea:focus {
   font-size: 11px;
   letter-spacing: 0.2em;
   text-transform: uppercase;
-  color: #8bd4ff;
+  color: #ffdaa1;
+}
+
+.start-screen {
+  position: absolute;
+  inset: 0;
+  z-index: 4;
+  display: grid;
+  place-items: center;
+  padding: 32px;
+  background:
+    radial-gradient(circle at 50% 38%, rgba(255, 219, 143, 0.12), transparent 24%),
+    radial-gradient(circle at 50% 62%, rgba(112, 255, 221, 0.1), transparent 30%),
+    linear-gradient(180deg, rgba(9, 6, 22, 0.34), rgba(9, 6, 22, 0.72));
+  backdrop-filter: blur(6px);
+}
+
+.start-card {
+  width: min(760px, 100%);
+  max-height: calc(100% - 24px);
+  overflow-y: auto;
+  border-radius: 34px;
+  padding: clamp(24px, 4vw, 42px);
+  display: grid;
+  gap: 22px;
+  text-align: center;
+}
+
+.start-hero {
+  display: grid;
+  gap: 14px;
+}
+
+.start-hero h1 {
+  margin: 0;
+  font-size: clamp(32px, 7vw, 65px);
+  line-height: 0.9;
+  letter-spacing: -0.04em;
+  text-shadow: 0 18px 44px rgba(0, 0, 0, 0.46);
+}
+
+.start-lede {
+  width: min(650px, 100%);
+  margin: 0 auto;
+  color: rgba(255, 244, 224, 0.86);
+  font-size: clamp(14px, 1.7vw, 16px);
+  line-height: 1.65;
+}
+
+.start-character-card {
+  width: 100%;
+  margin: 0 auto;
+  padding: 16px 18px;
+  border: 1px solid rgba(255, 226, 170, 0.14);
+  border-radius: 24px;
+  background:
+    radial-gradient(circle at 12% 0%, rgba(255, 218, 143, 0.11), transparent 40%),
+    rgba(255, 238, 190, 0.06);
+  text-align: left;
+}
+
+.start-character-label {
+  display: block;
+  margin-bottom: 7px;
+  color: rgba(255, 226, 173, 0.7);
+  font-size: 10px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+
+.start-character-card strong {
+  display: block;
+  color: #fff8e7;
+  font-size: 22px;
+  line-height: 1;
+}
+
+.start-character-card p {
+  margin: 8px 0 0;
+  color: rgba(255, 241, 214, 0.78);
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.start-feature-list {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 8px;
+}
+
+.start-feature-list span {
+  border: 1px solid rgba(255, 226, 170, 0.14);
+  border-radius: 999px;
+  padding: 8px 12px;
+  color: #fff3d6;
+  background: rgba(255, 238, 190, 0.08);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08);
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.start-model-form {
+  width: 100%;
+  margin: 0 auto;
+  display: grid;
+  gap: 14px;
+  text-align: left;
+}
+
+.start-status {
+  min-height: 22px;
+  text-align: center;
+  color: #d7c0ff;
+  font-size: 13px;
+  line-height: 1.55;
+}
+
+.start-button {
+  width:100%;
+  justify-self: center;
+  border-radius: 999px;
+  padding: 16px 28px;
+  font-size: 18px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
 }
 
 .controls-panel {
@@ -236,7 +409,7 @@ textarea:focus {
   margin: 0;
   font-size: 13px;
   line-height: 1.55;
-  color: rgba(224, 239, 255, 0.78);
+  color: rgba(255, 241, 214, 0.78);
 }
 
 .status-pill {
@@ -247,23 +420,23 @@ textarea:focus {
   font-weight: 700;
   letter-spacing: 0.14em;
   text-transform: uppercase;
-  background: rgba(255, 255, 255, 0.06);
-  color: #d8eaff;
+  background: rgba(255, 229, 171, 0.08);
+  color: #ffe5b1;
 }
 
 .status-pill.ready {
-  background: rgba(68, 219, 164, 0.14);
-  color: #90ffc9;
+  background: rgba(87, 255, 197, 0.14);
+  color: #92ffd9;
 }
 
 .status-pill.busy {
-  background: rgba(255, 198, 112, 0.14);
-  color: #ffd99d;
+  background: rgba(255, 198, 112, 0.16);
+  color: #ffe0a7;
 }
 
 .status-pill.idle {
-  background: rgba(129, 176, 255, 0.14);
-  color: #abd1ff;
+  background: rgba(164, 132, 255, 0.16);
+  color: #cfbdff;
 }
 
 .controls-form {
@@ -273,9 +446,14 @@ textarea:focus {
 
 .controls-toolbar {
   display: flex;
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
   gap: 10px;
   align-items: center;
+}
+
+.controls-toolbar button {
+  flex: 1 1 0;
+  white-space: nowrap;
 }
 
 .controls-fields {
@@ -287,16 +465,16 @@ textarea:focus {
   display: grid;
   gap: 6px;
   font-size: 12px;
-  color: rgba(219, 237, 255, 0.76);
+  color: rgba(255, 238, 206, 0.76);
 }
 
 .controls-toolbar > button:first-child {
-  min-width: 196px;
+  min-width: 146px;
 }
 
 .secondary-button {
-  background: rgba(255, 255, 255, 0.08);
-  color: #e0efff;
+  background: rgba(255, 238, 190, 0.08);
+  color: #fff1d5;
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08);
 }
 
@@ -304,7 +482,7 @@ textarea:focus {
   min-height: 20px;
   font-size: 12px;
   line-height: 1.55;
-  color: #a9d7ff;
+  color: #d7c0ff;
 }
 
 .history-toggle {
@@ -315,26 +493,26 @@ textarea:focus {
   gap: 6px;
   justify-items: start;
   text-align: left;
-  background: linear-gradient(180deg, rgba(13, 21, 39, 0.78), rgba(9, 15, 28, 0.78));
+  background: linear-gradient(180deg, rgba(28, 18, 45, 0.8), rgba(13, 9, 28, 0.82));
 }
 
 .history-toggle.active {
-  border-color: rgba(147, 212, 255, 0.26);
+  border-color: rgba(255, 219, 145, 0.32);
   box-shadow:
     inset 0 1px 0 rgba(255, 255, 255, 0.1),
-    0 18px 36px rgba(6, 12, 28, 0.38),
-    0 0 0 1px rgba(114, 188, 255, 0.18);
+    0 18px 36px rgba(6, 3, 18, 0.44),
+    0 0 0 1px rgba(255, 197, 102, 0.18);
 }
 
 .history-toggle-label {
   font-size: 14px;
   font-weight: 700;
-  color: #f2f7ff;
+  color: #fff6df;
 }
 
 .history-toggle-count {
   font-size: 12px;
-  color: rgba(197, 226, 255, 0.72);
+  color: rgba(236, 220, 255, 0.72);
 }
 
 .chat-composer {
@@ -343,6 +521,32 @@ textarea:focus {
   border-radius: 28px;
   display: grid;
   gap: 14px;
+}
+
+.prompt-suggestions {
+  display: flex;
+  gap: 8px;
+  overflow-x: auto;
+  padding: 2px 2px 6px;
+  scrollbar-width: thin;
+}
+
+.prompt-chip {
+  flex: 0 0 auto;
+  border: 1px solid rgba(255, 226, 170, 0.16);
+  padding: 8px 12px;
+  border-radius: 999px;
+  color: #fff3d6;
+  background: rgba(255, 238, 190, 0.08);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08);
+  font-size: 12px;
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+.prompt-chip:hover:not(:disabled) {
+  border-color: rgba(255, 220, 145, 0.34);
+  background: rgba(255, 220, 145, 0.14);
 }
 
 .chat-composer-header {
@@ -356,13 +560,91 @@ textarea:focus {
   margin-top: 6px;
   font-size: 20px;
   font-weight: 700;
-  color: #f4f9ff;
+  color: #fff8e7;
 }
 
 .chat-composer-hint {
   padding-top: 4px;
   font-size: 12px;
-  color: rgba(204, 229, 255, 0.7);
+  color: rgba(232, 214, 255, 0.72);
+}
+
+.actions-panel {
+  padding: 16px;
+  border-radius: 26px;
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr);
+  gap: 12px;
+  max-height: min(46vh, 520px);
+  overflow: hidden;
+}
+
+.actions-panel-header {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.actions-panel-title {
+  font-size: 16px;
+  font-weight: 800;
+  color: #fff5dd;
+}
+
+.actions-panel-groups {
+  min-height: 0;
+  overflow-y: auto;
+  display: grid;
+  gap: 12px;
+  padding-right: 8px;
+}
+
+.action-group {
+  display: grid;
+  gap: 8px;
+}
+
+.action-group-label {
+  font-size: 10px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: rgba(255, 226, 173, 0.68);
+}
+
+.action-buttons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.manual-action-button {
+  border: 1px solid rgba(255, 231, 180, 0.14);
+  padding: 9px 12px;
+  border-radius: 999px;
+  color: #fff5dc;
+  background: rgba(255, 238, 190, 0.08);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08);
+  font-size: 12px;
+  white-space: nowrap;
+}
+
+.manual-action-button.magic {
+  border-color: rgba(112, 255, 221, 0.22);
+  color: #c4fff4;
+  background: rgba(60, 255, 212, 0.1);
+}
+
+.manual-action-button.face,
+.manual-action-button.gaze {
+  border-color: rgba(196, 163, 255, 0.2);
+  color: #eadfff;
+  background: rgba(153, 113, 255, 0.1);
+}
+
+.manual-action-button:hover:not(:disabled) {
+  border-color: rgba(255, 220, 145, 0.34);
+  background: rgba(255, 220, 145, 0.14);
 }
 
 .chat-composer-row {
@@ -379,30 +661,12 @@ textarea:focus {
   line-height: 1.5;
 }
 
-.transcript-backdrop {
-  position: absolute;
-  inset: 0;
-  z-index: 3;
-  border: 0;
-  padding: 0;
-  pointer-events: none;
-  opacity: 0;
-  background: rgba(4, 9, 19, 0.18);
-  backdrop-filter: blur(2px);
-  transition: opacity 180ms ease;
-}
-
-.transcript-backdrop.open {
-  pointer-events: auto;
-  opacity: 1;
-}
-
 .transcript-drawer {
   position: absolute;
   top: 18px;
   right: 18px;
   bottom: 18px;
-  z-index: 4;
+  z-index: 2;
   width: min(380px, calc(100vw - 36px));
   border-radius: 28px;
   padding: 18px;
@@ -444,8 +708,8 @@ textarea:focus {
   align-self: stretch;
   padding: 14px 16px;
   border-radius: 16px;
-  background: rgba(255, 255, 255, 0.04);
-  color: rgba(213, 232, 255, 0.76);
+  background: rgba(255, 238, 190, 0.05);
+  color: rgba(255, 239, 213, 0.76);
   line-height: 1.5;
   font-size: 13px;
 }
@@ -453,8 +717,8 @@ textarea:focus {
 .transcript-entry {
   padding: 6px 12px 8px;
   border-radius: 14px;
-  background: rgba(255, 255, 255, 0.05);
-  border: 1px solid rgba(255, 255, 255, 0.06);
+  background: rgba(255, 238, 190, 0.05);
+  border: 1px solid rgba(255, 238, 190, 0.07);
   display: flex;
   flex-direction: column;
   gap: 2px;
@@ -464,14 +728,14 @@ textarea:focus {
 }
 
 .transcript-entry.user {
-  background: rgba(112, 155, 255, 0.14);
-  border-color: rgba(144, 188, 255, 0.18);
+  background: rgba(139, 103, 255, 0.16);
+  border-color: rgba(190, 166, 255, 0.2);
   align-self: flex-end;
   margin-right: 6px;
 }
 
 .transcript-entry.assistant {
-  background: rgba(255, 255, 255, 0.05);
+  background: rgba(255, 226, 163, 0.06);
   align-self: flex-start;
   margin-left: 6px;
 }
@@ -500,11 +764,11 @@ textarea:focus {
 }
 
 .transcript-role {
-  color: #97d9ff;
+  color: #ffdaa1;
 }
 
 .transcript-pending {
-  color: #ffd89a;
+  color: #b9fff1;
 }
 
 .transcript-actions {
@@ -516,7 +780,7 @@ textarea:focus {
 .transcript-text {
   white-space: pre-wrap;
   line-height: 1.4;
-  color: #eff5ff;
+  color: #fff7e7;
   font-size: 14px;
   margin: 0;
 }
@@ -526,8 +790,8 @@ textarea:focus {
   align-items: center;
   padding: 4px 10px;
   border-radius: 999px;
-  background: rgba(123, 193, 255, 0.16);
-  color: #b6deff;
+  background: rgba(113, 255, 218, 0.14);
+  color: #c7fff4;
   font-size: 11px;
   font-weight: 700;
   letter-spacing: 0.04em;
@@ -535,7 +799,7 @@ textarea:focus {
 
 .cursor {
   margin-left: 4px;
-  color: #9ee3ff;
+  color: #82ffe5;
 }
 
 .overlay {
@@ -547,9 +811,9 @@ textarea:focus {
   padding: 9px 14px;
   border-radius: 999px;
   font-size: 12px;
-  color: #eff6ff;
-  background: rgba(3, 10, 24, 0.54);
-  border: 1px solid rgba(172, 215, 255, 0.12);
+  color: #fff6df;
+  background: rgba(10, 7, 24, 0.6);
+  border: 1px solid rgba(255, 218, 149, 0.14);
   pointer-events: none;
   backdrop-filter: blur(12px);
 }
@@ -579,6 +843,12 @@ textarea:focus {
     right: 12px;
   }
 
+  .stage-actions {
+    left: 12px;
+    top: 356px;
+    width: min(340px, calc(100% - 24px));
+  }
+
   .stage-bottom {
     left: 12px;
     right: 12px;
@@ -593,6 +863,35 @@ textarea:focus {
 }
 
 @media (max-width: 760px) {
+  .start-screen {
+    padding: 14px;
+    align-items: stretch;
+  }
+
+  .start-card {
+    max-height: calc(100% - 12px);
+    align-self: center;
+    border-radius: 28px;
+    gap: 18px;
+  }
+
+  .start-character-card {
+    text-align: center;
+  }
+
+  .start-feature-list {
+    justify-content: stretch;
+  }
+
+  .start-feature-list span {
+    flex: 1 1 100%;
+    text-align: center;
+  }
+
+  .start-button {
+    width: 100%;
+  }
+
   .stage-shell {
     min-height: 100vh;
     height: calc(100vh - 24px);
@@ -633,11 +932,44 @@ textarea:focus {
     padding: 12px 14px;
   }
 
+  .stage-actions {
+    top: auto;
+    left: 12px;
+    right: 12px;
+    bottom: 216px;
+    width: auto;
+  }
+
+  .actions-panel {
+    max-height: 170px;
+    padding: 12px;
+  }
+
+  .actions-panel-groups {
+    display: flex;
+    overflow-x: auto;
+    overflow-y: hidden;
+    gap: 14px;
+    padding-right: 0;
+    padding-bottom: 6px;
+  }
+
+  .action-group {
+    min-width: min(270px, 78vw);
+  }
+
+  .action-buttons {
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    padding-bottom: 3px;
+  }
+
   .transcript-drawer {
     width: calc(100vw - 24px);
   }
 
   .chat-composer {
+    width: 100%;
     padding: 16px;
     border-radius: 24px;
   }


### PR DESCRIPTION
This pull request transforms the `apps/avatar` demo from a generic co-working persona into a high-fantasy, anime-inspired avatar experience centered on Aria, a Dawnblade knight. The changes overhaul the character's persona, actions, and in-app presentation to create a more immersive, themed interaction. The app now features a fantasy ruin stage, a curated set of suggested prompts, a new start screen, and expanded manual action controls, all tailored for the new setting.

**Key changes include:**

### Thematic and Content Overhaul

- **Aria’s Persona and World:** The `character.json` file has been completely rewritten to reimagine Aria as a heroic fantasy knight guarding a magical gate. Her summary, backstory, personality traits, dialogue style, and sample responses are now all high-fantasy themed, with explicit instructions to treat the setting as real and avoid any AI or demo references.
- **Expanded and Themed Actions:** The action schema now includes detailed fantasy cues for body, facial, gaze, and magical effects, each with richer descriptions and usage hints. New actions like `summon_familiar`, `cast_starbolt`, and `raise_ward` have been added, with more expressive cues and emotional beats.

### User Experience and UI Improvements

- **Start Screen and Default Model:** A new start screen (`StartScreen` component) is introduced, pre-populating a default `.gguf` model URL and allowing the user to begin the demo with a single click. The character is now always loaded from a fixed URL, simplifying setup. [[1]](diffhunk://#diff-b669fc61aa7d2ba05b813d5a73b99124abef2d0b04708fdac18261bc7eb6bfc8L45-R69) [[2]](diffhunk://#diff-b669fc61aa7d2ba05b813d5a73b99124abef2d0b04708fdac18261bc7eb6bfc8R376-R386)
- **Suggested Prompts:** The chat composer now displays fantasy-themed suggested prompts to help users quickly engage with Aria’s new persona. [[1]](diffhunk://#diff-b669fc61aa7d2ba05b813d5a73b99124abef2d0b04708fdac18261bc7eb6bfc8L45-R69) [[2]](diffhunk://#diff-b669fc61aa7d2ba05b813d5a73b99124abef2d0b04708fdac18261bc7eb6bfc8L317-R366)
- **Transcript Drawer and Manual Actions:** The transcript drawer opens by default for better onboarding, and a new `ActionsPanel` allows users to directly trigger any of Aria’s configured actions, supporting the expanded action set. [[1]](diffhunk://#diff-b669fc61aa7d2ba05b813d5a73b99124abef2d0b04708fdac18261bc7eb6bfc8L257-R288) [[2]](diffhunk://#diff-b669fc61aa7d2ba05b813d5a73b99124abef2d0b04708fdac18261bc7eb6bfc8L317-R366)

### Demo and Documentation Updates

- **README and Demo Description:** The `README.md` now describes the fantasy setting, interaction layers, and action coverage, including a list of all available actions and their intended effects. [[1]](diffhunk://#diff-219c9a4ed615221ad236be07fe837b3bc045a0f76701331af01162cc18f6aabaL3-R11) [[2]](diffhunk://#diff-219c9a4ed615221ad236be07fe837b3bc045a0f76701331af01162cc18f6aabaL22-R88)

These changes collectively shift the demo from a generic avatar to a richly characterized, interactive fantasy experience.

- Aria’s persona, actions, and sample interactions rewritten for a high-fantasy setting, with detailed instructions for immersive, in-character responses.
- Expanded action schema with new fantasy-themed cues and richer emotional/physical beats.
- New start screen with default model URL and simplified character loading. [[1]](diffhunk://#diff-b669fc61aa7d2ba05b813d5a73b99124abef2d0b04708fdac18261bc7eb6bfc8L45-R69) [[2]](diffhunk://#diff-b669fc61aa7d2ba05b813d5a73b99124abef2d0b04708fdac18261bc7eb6bfc8R376-R386)
- Suggested prompt chips and always-open transcript drawer for improved onboarding and engagement. [[1]](diffhunk://#diff-b669fc61aa7d2ba05b813d5a73b99124abef2d0b04708fdac18261bc7eb6bfc8L45-R69) [[2]](diffhunk://#diff-b669fc61aa7d2ba05b813d5a73b99124abef2d0b04708fdac18261bc7eb6bfc8L317-R366)
- Updated README to reflect the new fantasy demo, stage design, and action coverage. [[1]](diffhunk://#diff-219c9a4ed615221ad236be07fe837b3bc045a0f76701331af01162cc18f6aabaL3-R11) [[2]](diffhunk://#diff-219c9a4ed615221ad236be07fe837b3bc045a0f76701331af01162cc18f6aabaL22-R88)