### PR TITLE
Fix and add public release package root for builds

### DIFF
--- a/.github/workflows/publish-cogentlm.yml
+++ b/.github/workflows/publish-cogentlm.yml
@@ -200,6 +200,8 @@ jobs:
         run: bun test packages/cogentlm/src
 
       - name: Build and validate release package
+        env:
+          COGENTLM_PACKAGE_ROOT: node_modules/cogentlm
         run: bun run --filter=@noumena-labs/cogentlm release:prepare
 
       - name: Run built package smoke test

--- a/packages/cogentlm/scripts/build-ts.mjs
+++ b/packages/cogentlm/scripts/build-ts.mjs
@@ -11,6 +11,22 @@ const tempEsmDir = path.join(tempRoot, 'esm');
 const tempTypesDir = path.join(tempRoot, 'types');
 const esmDir = path.join(distDir, 'esm');
 const typesDir = path.join(distDir, 'types');
+const packageRootEnvVar = 'COGENTLM_PACKAGE_ROOT';
+const internalPackageRoot = 'node_modules/@noumena-labs/cogentlm';
+const publicPackageRoot = 'node_modules/cogentlm';
+const supportedPackageRoots = new Set([internalPackageRoot, publicPackageRoot]);
+
+function getPackageRoot() {
+  const packageRoot = process.env[packageRootEnvVar]?.trim() || internalPackageRoot;
+
+  if (!supportedPackageRoots.has(packageRoot)) {
+    throw new Error(
+      `${packageRootEnvVar} must be one of: ${Array.from(supportedPackageRoots).join(', ')}`
+    );
+  }
+
+  return packageRoot;
+}
 
 async function pathIsDirectory(targetPath) {
   try {
@@ -119,12 +135,39 @@ async function preserveBundlerDirectives() {
   await writeFile(runtimePath, patchedRuntimeText);
 }
 
+async function applyPackageRootOverride() {
+  const packageRoot = getPackageRoot();
+
+  if (packageRoot === internalPackageRoot) {
+    return;
+  }
+
+  const packageAssetsPath = path.join(tempEsmDir, 'runtime', 'package-assets.js');
+  const packageAssetsText = await readFile(packageAssetsPath, 'utf8');
+  const internalPackageRootStatement = `const PACKAGE_ROOT = '${internalPackageRoot}';`;
+
+  if (!packageAssetsText.includes(internalPackageRootStatement)) {
+    throw new Error('Could not find the default PACKAGE_ROOT statement in runtime/package-assets.js.');
+  }
+
+  await writeFile(
+    packageAssetsPath,
+    packageAssetsText.replace(
+      internalPackageRootStatement,
+      `const PACKAGE_ROOT = '${packageRoot}';`
+    )
+  );
+
+  console.log(`[build-ts] package asset root: ${packageRoot}`);
+}
+
 await rm(tempRoot, { recursive: true, force: true });
 await mkdir(tempRoot, { recursive: true });
 
 try {
   await runTypeScriptBuild();
   await preserveBundlerDirectives();
+  await applyPackageRootOverride();
   await syncTypeScriptDist();
   console.log('[build-ts] updated dist/esm and dist/types');
 } finally {

--- a/packages/cogentlm/scripts/validate-pack.mjs
+++ b/packages/cogentlm/scripts/validate-pack.mjs
@@ -6,6 +6,10 @@ import { fileURLToPath } from 'node:url';
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const packageDir = path.resolve(scriptDir, '..');
 const npmCommand = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+const packageRootEnvVar = 'COGENTLM_PACKAGE_ROOT';
+const internalPackageRoot = 'node_modules/@noumena-labs/cogentlm';
+const publicPackageRoot = 'node_modules/cogentlm';
+const supportedPackageRoots = new Set([internalPackageRoot, publicPackageRoot]);
 const requiredPackPaths = [
   'dist/esm/index.js',
   'dist/esm/runtime/package-assets.js',
@@ -26,6 +30,16 @@ const requiredPackPaths = [
 function fail(message) {
   console.error(`[pack:validate] ${message}`);
   process.exit(1);
+}
+
+function getExpectedPackageRoot() {
+  const packageRoot = process.env[packageRootEnvVar]?.trim() || internalPackageRoot;
+
+  if (!supportedPackageRoots.has(packageRoot)) {
+    fail(`${packageRootEnvVar} must be one of: ${Array.from(supportedPackageRoots).join(', ')}`);
+  }
+
+  return packageRoot;
 }
 
 const packResult = spawnSync(npmCommand, ['pack', '--dry-run', '--json'], {
@@ -61,9 +75,11 @@ if (missingPaths.length > 0) {
 const workerClientPath = path.join(packageDir, 'dist', 'esm', 'worker', 'model-service-client.js');
 const workerEntryPath = path.join(packageDir, 'dist', 'esm', 'worker', 'model-service-entry.js');
 const runtimePath = path.join(packageDir, 'dist', 'esm', 'runtime', 'engine-runtime-main-thread.js');
+const packageAssetsPath = path.join(packageDir, 'dist', 'esm', 'runtime', 'package-assets.js');
 const workerClientText = readFileSync(workerClientPath, 'utf8');
 const workerEntryText = readFileSync(workerEntryPath, 'utf8');
 const runtimeText = readFileSync(runtimePath, 'utf8');
+const packageAssetsText = readFileSync(packageAssetsPath, 'utf8');
 
 if (!workerClientText.includes("new Worker(new URL('./model-service-entry.js', import.meta.url)")) {
   fail(
@@ -87,6 +103,11 @@ if (!runtimeText.includes('import(/* @vite-ignore */ moduleUrl)')) {
   fail(
     'Runtime module import must preserve /* @vite-ignore */ in dist so Vite does not try to statically analyze user-configurable moduleUrl.'
   );
+}
+
+const expectedPackageRoot = getExpectedPackageRoot();
+if (!packageAssetsText.includes(`const PACKAGE_ROOT = '${expectedPackageRoot}';`)) {
+  fail(`Runtime package asset resolver must use PACKAGE_ROOT '${expectedPackageRoot}'.`);
 }
 
 console.log(


### PR DESCRIPTION
This pull request introduces support for customizing the package root directory for the `cogentlm` package, making the build and validation scripts more flexible for different deployment scenarios. The main enhancements include adding environment variable support, updating build and validation logic, and improving error handling for package root overrides.

**Build and validation improvements:**

* Added support for a `COGENTLM_PACKAGE_ROOT` environment variable to allow overriding the default package root directory in both build (`build-ts.mjs`) and validation (`validate-pack.mjs`) scripts. [[1]](diffhunk://#diff-c9d45d8669008e63a46b32e4ac9ba6928bf1e7c6ae553528930799c8d7bc14bfR14-R29) [[2]](diffhunk://#diff-b5d24965930d5eefb44175124780151b2be7c26a38b778163a0b82eed2977362R9-R12)
* Updated the build script to patch the package asset resolver (`runtime/package-assets.js`) to use the overridden package root if specified.
* Enhanced the validation script to check that the built package uses the correct package root based on the environment variable. [[1]](diffhunk://#diff-b5d24965930d5eefb44175124780151b2be7c26a38b778163a0b82eed2977362R35-R44) [[2]](diffhunk://#diff-b5d24965930d5eefb44175124780151b2be7c26a38b778163a0b82eed2977362R78-R82) [[3]](diffhunk://#diff-b5d24965930d5eefb44175124780151b2be7c26a38b778163a0b82eed2977362R108-R112)

**CI/CD workflow update:**

* Updated the GitHub Actions workflow (`publish-cogentlm.yml`) to set the `COGENTLM_PACKAGE_ROOT` environment variable during the build and validation steps.