### PR TITLE
Fix app example dependencies

### DIFF
--- a/apps/avatar/src/App.tsx
+++ b/apps/avatar/src/App.tsx
@@ -16,7 +16,7 @@ import {
   parseCharacterConfig,
   type CharacterConfig,
   type CharacterRuntime,
-} from 'cogentlm/character';
+} from '@noumena-labs/cogentlm/character';
 import { AvatarCanvas } from './components/AvatarCanvas';
 import { ChatComposer } from './components/ChatComposer';
 import {

--- a/apps/avatar/vite.config.ts
+++ b/apps/avatar/vite.config.ts
@@ -21,6 +21,7 @@ export default defineConfig({
       // Resolve both the root package entry and the ./character subpath
       // directly at the built ESM files so we pick up local rebuilds without
       // going through a cached /node_modules dependency URL.
+      '@noumena-labs/cogentlm/character': cogentEngineCharacterEntry,
       'cogentlm/character': cogentEngineCharacterEntry,
       '@noumena-labs/cogentlm': cogentEngineEntry,
     },

--- a/apps/simulation/src/App.tsx
+++ b/apps/simulation/src/App.tsx
@@ -14,7 +14,7 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from 'react';
 import { CogentEngine } from '@noumena-labs/cogentlm';
-import { createDirectorFromConfigUrl } from 'cogentlm/director';
+import { createDirectorFromConfigUrl } from '@noumena-labs/cogentlm/director';
 import { BrainActivityHud } from './components/BrainActivityHud';
 import { BrainTraceDrawer } from './components/BrainTraceDrawer';
 import { SimulationCanvas } from './components/SimulationCanvas';

--- a/apps/simulation/src/runtime/traced-engine.ts
+++ b/apps/simulation/src/runtime/traced-engine.ts
@@ -1,6 +1,6 @@
 import type { ChatInput, ChatOptions, CogentEngine, QueryInput, QueryOptions } from '@noumena-labs/cogentlm';
-import type { CharacterRuntimeEngine } from 'cogentlm/character';
-import type { DirectorRuntimeEngine } from 'cogentlm/director';
+import type { CharacterRuntimeEngine } from '@noumena-labs/cogentlm/character';
+import type { DirectorRuntimeEngine } from '@noumena-labs/cogentlm/director';
 import type { BrainDefinition, BrainQueryType, BrainQueryStatus, BrainActivityStore } from './brain-activity-store.js';
 
 interface TracedChatMessage {

--- a/apps/simulation/vite.config.ts
+++ b/apps/simulation/vite.config.ts
@@ -22,6 +22,8 @@ export default defineConfig({
   plugins: [react(), cogentEngineDistWatch()],
   resolve: {
     alias: {
+      '@noumena-labs/cogentlm/director': cogentEngineDirectorEntry,
+      '@noumena-labs/cogentlm/character': cogentEngineCharacterEntry,
       'cogentlm/director': cogentEngineDirectorEntry,
       'cogentlm/character': cogentEngineCharacterEntry,
       '@noumena-labs/cogentlm': cogentEngineEntry,


### PR DESCRIPTION
This pull request updates import paths throughout the `avatar` and `simulation` apps to use the new `@noumena-labs` scoped package names for `cogentlm/character` and `cogentlm/director`. It also ensures that Vite's alias configuration recognizes these new paths, enabling proper local development and module resolution.

**Dependency import updates:**

* Changed imports from `cogentlm/character` and `cogentlm/director` to their new scoped equivalents `@noumena-labs/cogentlm/character` and `@noumena-labs/cogentlm/director` in `apps/avatar/src/App.tsx`, `apps/simulation/src/App.tsx`, and `apps/simulation/src/runtime/traced-engine.ts` [[1]](diffhunk://#diff-b669fc61aa7d2ba05b813d5a73b99124abef2d0b04708fdac18261bc7eb6bfc8L19-R19) [[2]](diffhunk://#diff-07569d0ee6a9757b854f7a3cf310ed91994ee3576cad7ef32034892d02f02bfdL17-R17) [[3]](diffhunk://#diff-8f7411f42c886793c29ba7de92365aa392efd85ac4f6502d631e8b0e358679a9L2-R3).

**Vite alias configuration:**

* Added aliases for `@noumena-labs/cogentlm/character` and `@noumena-labs/cogentlm/director` in `apps/avatar/vite.config.ts` and `apps/simulation/vite.config.ts` to point to the correct local build outputs, ensuring local development uses the latest code. [[1]](diffhunk://#diff-ac5d8b133b0eee188e8777de2c44db2b2a8aeacc6730da028e663bdec44ba526R24) [[2]](diffhunk://#diff-f93e433774d99ebebd4427e772c05ab0314b720b5452fb4f3eda84ccfad37f27R25-R26)