### PR TITLE
Fix start panel for simulation

### DIFF
--- a/apps/simulation/src/style.css
+++ b/apps/simulation/src/style.css
@@ -273,6 +273,10 @@ html, body, #app {
 
 .start-panel {
   width: min(720px, 100%);
+  max-height: calc(100vh - 48px);
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  scrollbar-gutter: stable;
   padding: 28px;
   background: linear-gradient(180deg, rgba(32, 38, 59, 0.9), rgba(18, 22, 35, 0.88));
   border-color: rgba(255, 216, 107, 0.18);
@@ -1238,6 +1242,7 @@ html, body, #app {
   }
 
   .start-panel {
+    max-height: calc(100vh - 36px);
     padding: 22px;
   }
 


### PR DESCRIPTION
This pull request makes improvements to the styling of the `.start-panel` component in the simulation app to enhance its usability, especially on smaller screens or when content overflows. The main focus is on controlling the panel's maximum height and improving scrolling behavior.

Styling improvements for `.start-panel`:

* Added a `max-height` property to `.start-panel` to restrict its height relative to the viewport, preventing it from exceeding the visible area and improving layout on smaller screens. [[1]](diffhunk://#diff-899b1d9ea025981f102842816d9af00f21a2838655373c8f2d1d0171e143ba21R276-R279) [[2]](diffhunk://#diff-899b1d9ea025981f102842816d9af00f21a2838655373c8f2d1d0171e143ba21R1245)
* Enabled vertical scrolling within `.start-panel` by setting `overflow-y: auto`, ensuring content remains accessible when it exceeds the panel's height.
* Added `overscroll-behavior: contain` and `scrollbar-gutter: stable` to provide a smoother and more consistent scrolling experience within the panel.