### PR TITLE
Fix MAX token hard constraint artifact

### DIFF
--- a/packages/cogentlm/native/api/engine_bridge.cpp
+++ b/packages/cogentlm/native/api/engine_bridge.cpp
@@ -30,14 +30,13 @@ constexpr int kCompletedRequestStatusCompleted = 1;
 constexpr int kCompletedRequestStatusCancelled = 2;
 constexpr int kCompletedRequestStatusFailed = 3;
 constexpr int kCompletedRequestStatusUnknown = 4;
-constexpr int kMaxPredictionTokens = 2048;
 
 std::mutex g_engineMutex;
 std::shared_ptr<InferenceRuntime> g_engineRuntime;
 using json = nlohmann::json;
 
 bool is_valid_prediction_tokens(int token_count) {
-  return token_count > 0 && token_count <= kMaxPredictionTokens;
+  return token_count > 0;
 }
 
 bool map_token_emission_mode(CE_TokenEmissionMode mode,

--- a/packages/cogentlm/native/api/wasm_exports.cpp
+++ b/packages/cogentlm/native/api/wasm_exports.cpp
@@ -13,10 +13,9 @@ namespace {
 constexpr int kStatusFailure = -1;
 constexpr int kStatusInvalidArguments = -2;
 constexpr int kStatusNotInitialized = -3;
-constexpr int kMaxPromptTokens = 2048;
 
 bool is_valid_prediction_tokens(int token_count) {
-  return token_count > 0 && token_count <= kMaxPromptTokens;
+  return token_count > 0;
 }
 
 bool g_isEngineInitialized = false;

--- a/packages/cogentlm/native/runtime/inference_runtime.cpp
+++ b/packages/cogentlm/native/runtime/inference_runtime.cpp
@@ -27,7 +27,6 @@
 namespace {
 
 constexpr char kDefaultPromptContextKey[] = "__primary_prompt__";
-constexpr int kMaxPredictionTokens = 2048;
 
 using BitmapPtr = std::unique_ptr<mtmd_bitmap, decltype(&mtmd_bitmap_free)>;
 using InputChunksPtr =
@@ -1884,7 +1883,7 @@ GenerateRequestId InferenceRuntime::EnqueueRequest(
   if (primary_model_ == nullptr || sampler_ == nullptr) {
     return 0;
   }
-  if (n_tokens_predict <= 0 || n_tokens_predict > kMaxPredictionTokens) {
+  if (n_tokens_predict <= 0) {
     return 0;
   }
   if (context_key.empty()) {
@@ -1933,7 +1932,7 @@ GenerateRequestId InferenceRuntime::EnqueueMultimodalRequest(
       mtmd_ctx_ == nullptr || !mtmd_support_vision(mtmd_ctx_)) {
     return 0;
   }
-  if (n_tokens_predict <= 0 || n_tokens_predict > kMaxPredictionTokens) {
+  if (n_tokens_predict <= 0) {
     return 0;
   }
   if (image_views.empty()) {

--- a/packages/cogentlm/native/runtime/scheduler/slot_scheduler.cpp
+++ b/packages/cogentlm/native/runtime/scheduler/slot_scheduler.cpp
@@ -54,12 +54,6 @@ void SlotState::AttachRequest(GenerateRequest &request_ref,
   decode_step_count = 0;
   batch_participation_count = 0;
   generated_tokens.clear();
-  if (request_ref.max_output_tokens > 0) {
-    generated_tokens.reserve(static_cast<std::size_t>(
-        std::max<int32_t>(1, request_ref.max_output_tokens)));
-    output_text.reserve(static_cast<std::size_t>(
-        std::max<int32_t>(16, request_ref.max_output_tokens * 4)));
-  }
   output_text.clear();
   buffered_output_text.clear();
   pending_utf8_bytes.clear();

--- a/packages/cogentlm/src/runtime/engine-runtime-main-thread.test.ts
+++ b/packages/cogentlm/src/runtime/engine-runtime-main-thread.test.ts
@@ -4,26 +4,6 @@ import { MainThreadEngineRuntime } from './engine-runtime-main-thread.js';
 import type { EngineModule } from '../wasm/engine-module.js';
 import type { StagedModelBundle } from '../types.js';
 
-type TestBridge = {
-  startTextRequest?: (
-    contextKey: string,
-    promptText: string,
-    maxOutputTokens: number,
-    callbackPtr: number,
-    grammar?: string,
-    tokenEmissionMode?: number
-  ) => number;
-  startMediaRequest?: (
-    contextKey: string,
-    promptText: string,
-    maxOutputTokens: number,
-    media: Uint8Array[],
-    callbackPtr: number,
-    grammar?: string,
-    tokenEmissionMode?: number
-  ) => number;
-};
-
 function createModule(): EngineModule {
   return {
     FS: {
@@ -44,63 +24,6 @@ function createModule(): EngineModule {
     UTF8ToString: () => '',
   };
 }
-
-function createReadyRuntimeWithBridge(bridge: TestBridge): MainThreadEngineRuntime {
-  const runtime = new MainThreadEngineRuntime({ executionMode: 'main-thread' });
-  const internals = runtime as unknown as {
-    module: EngineModule;
-    engineInitialized: boolean;
-    wasmBridge: TestBridge;
-  };
-  internals.module = createModule();
-  internals.engineInitialized = true;
-  internals.wasmBridge = bridge;
-  return runtime;
-}
-
-test('MainThreadEngineRuntime allows output token counts above the old artifact limit', async () => {
-  let capturedMaxOutputTokens: number | undefined;
-  const runtime = createReadyRuntimeWithBridge({
-    startTextRequest: (_contextKey, _promptText, maxOutputTokens) => {
-      capturedMaxOutputTokens = maxOutputTokens;
-      return 101;
-    },
-  });
-
-  const requestId = await runtime.enqueueQuery('context', 'prompt', {
-    nTokens: 2049,
-  });
-
-  assert.equal(requestId, 101);
-  assert.equal(capturedMaxOutputTokens, 2049);
-});
-
-test('MainThreadEngineRuntime rejects non-positive and non-integer nTokens', async () => {
-  let enqueueCount = 0;
-  const runtime = createReadyRuntimeWithBridge({
-    startTextRequest: () => {
-      enqueueCount += 1;
-      return 102;
-    },
-  });
-
-  const invalidValues: Array<{ value: number; message: RegExp }> = [
-    { value: 0, message: /positive integer/ },
-    { value: -1, message: /positive integer/ },
-    { value: 1.5, message: /integer/ },
-  ];
-
-  for (const invalidValue of invalidValues) {
-    await assert.rejects(
-      () =>
-        runtime.enqueueQuery('context', 'prompt', {
-          nTokens: invalidValue.value,
-        }),
-      invalidValue.message
-    );
-  }
-  assert.equal(enqueueCount, 0);
-});
 
 test('MainThreadEngineRuntime fails projector-backed loads that do not expose a media marker', async () => {
   const runtime = new MainThreadEngineRuntime({

--- a/packages/cogentlm/src/runtime/engine-runtime-main-thread.test.ts
+++ b/packages/cogentlm/src/runtime/engine-runtime-main-thread.test.ts
@@ -4,6 +4,26 @@ import { MainThreadEngineRuntime } from './engine-runtime-main-thread.js';
 import type { EngineModule } from '../wasm/engine-module.js';
 import type { StagedModelBundle } from '../types.js';
 
+type TestBridge = {
+  startTextRequest?: (
+    contextKey: string,
+    promptText: string,
+    maxOutputTokens: number,
+    callbackPtr: number,
+    grammar?: string,
+    tokenEmissionMode?: number
+  ) => number;
+  startMediaRequest?: (
+    contextKey: string,
+    promptText: string,
+    maxOutputTokens: number,
+    media: Uint8Array[],
+    callbackPtr: number,
+    grammar?: string,
+    tokenEmissionMode?: number
+  ) => number;
+};
+
 function createModule(): EngineModule {
   return {
     FS: {
@@ -24,6 +44,63 @@ function createModule(): EngineModule {
     UTF8ToString: () => '',
   };
 }
+
+function createReadyRuntimeWithBridge(bridge: TestBridge): MainThreadEngineRuntime {
+  const runtime = new MainThreadEngineRuntime({ executionMode: 'main-thread' });
+  const internals = runtime as unknown as {
+    module: EngineModule;
+    engineInitialized: boolean;
+    wasmBridge: TestBridge;
+  };
+  internals.module = createModule();
+  internals.engineInitialized = true;
+  internals.wasmBridge = bridge;
+  return runtime;
+}
+
+test('MainThreadEngineRuntime allows output token counts above the old artifact limit', async () => {
+  let capturedMaxOutputTokens: number | undefined;
+  const runtime = createReadyRuntimeWithBridge({
+    startTextRequest: (_contextKey, _promptText, maxOutputTokens) => {
+      capturedMaxOutputTokens = maxOutputTokens;
+      return 101;
+    },
+  });
+
+  const requestId = await runtime.enqueueQuery('context', 'prompt', {
+    nTokens: 2049,
+  });
+
+  assert.equal(requestId, 101);
+  assert.equal(capturedMaxOutputTokens, 2049);
+});
+
+test('MainThreadEngineRuntime rejects non-positive and non-integer nTokens', async () => {
+  let enqueueCount = 0;
+  const runtime = createReadyRuntimeWithBridge({
+    startTextRequest: () => {
+      enqueueCount += 1;
+      return 102;
+    },
+  });
+
+  const invalidValues: Array<{ value: number; message: RegExp }> = [
+    { value: 0, message: /positive integer/ },
+    { value: -1, message: /positive integer/ },
+    { value: 1.5, message: /integer/ },
+  ];
+
+  for (const invalidValue of invalidValues) {
+    await assert.rejects(
+      () =>
+        runtime.enqueueQuery('context', 'prompt', {
+          nTokens: invalidValue.value,
+        }),
+      invalidValue.message
+    );
+  }
+  assert.equal(enqueueCount, 0);
+});
 
 test('MainThreadEngineRuntime fails projector-backed loads that do not expose a media marker', async () => {
   const runtime = new MainThreadEngineRuntime({

--- a/packages/cogentlm/src/runtime/engine-runtime-main-thread.ts
+++ b/packages/cogentlm/src/runtime/engine-runtime-main-thread.ts
@@ -19,7 +19,6 @@ import { MainThreadModelLoader } from './main-thread-model-loader.js';
 import {
   COMPLETED_REQUEST_STATUS_PENDING,
   DEFAULT_MAIN_THREAD_TRANSPORT_OBSERVABILITY,
-  MAX_PROMPT_TOKENS,
 } from './main-thread-runtime-constants.js';
 import { RequestTracker } from './request-tracker.js';
 import {
@@ -95,8 +94,8 @@ export class MainThreadEngineRuntime implements EngineRuntime {
     if (!Number.isInteger(nTokens)) {
       throw new Error('nTokens must be an integer.');
     }
-    if (nTokens <= 0 || nTokens > MAX_PROMPT_TOKENS) {
-      throw new Error(`nTokens must be between 1 and ${MAX_PROMPT_TOKENS}.`);
+    if (nTokens <= 0) {
+      throw new Error('nTokens must be a positive integer.');
     }
     return nTokens;
   }

--- a/packages/cogentlm/src/runtime/main-thread-runtime-constants.ts
+++ b/packages/cogentlm/src/runtime/main-thread-runtime-constants.ts
@@ -2,7 +2,6 @@ import { TransportObservability } from '../types.js';
 
 export type MountableModelFile = Blob & { name?: string };
 
-export const MAX_PROMPT_TOKENS = 2048;
 export const DEFAULT_MAX_MODEL_BYTES = 8 * 1024 * 1024 * 1024;
 export const REQUEST_STEP_RESULT_INVALID = -1;
 export const REQUEST_STEP_RESULT_FATAL_NO_PROGRESS = -2;


### PR DESCRIPTION
This pull request removes the previous hard-coded limit of 2048 maximum output tokens for prediction requests, allowing for larger output sizes. It updates validation logic in both the C++ backend and TypeScript frontend to only require that the requested token count is a positive integer, and adds tests to verify this behavior. Additionally, it cleans up related constants and code that enforced the old limit.

**Removal of maximum token limit (2048):**
- Removed the `kMaxPredictionTokens` and `kMaxPromptTokens` constants from C++ backend files and the `MAX_PROMPT_TOKENS` constant from TypeScript, eliminating the enforced upper bound on prediction tokens. [[1]](diffhunk://#diff-7d396f31606fac842d8ef32d36bb13572a830ec41adec3f635c877da699d97e4L33-R39) [[2]](diffhunk://#diff-e431298f699282a9a620d0a99485978aa7257e31ae6411fe801d0ada8d1b8646L16-R18) [[3]](diffhunk://#diff-3571d501379798395eeef75948a29d084dc3a3d122057eb4ab80425c6929a3b1L30) [[4]](diffhunk://#diff-ba600d89ab4bb0332e04efe3ba78954867d32fbb9af1dfd31d24092b67c46e07L5)
- Updated validation logic in `InferenceRuntime::EnqueueRequest` and `InferenceRuntime::EnqueueMultimodalRequest` to only check for positive token counts, not an upper limit. [[1]](diffhunk://#diff-3571d501379798395eeef75948a29d084dc3a3d122057eb4ab80425c6929a3b1L1887-R1886) [[2]](diffhunk://#diff-3571d501379798395eeef75948a29d084dc3a3d122057eb4ab80425c6929a3b1L1936-R1935)
- Modified the frontend validation in `MainThreadEngineRuntime` to only require that `nTokens` is a positive integer, removing the upper bound check.

