### PR TITLE
Local Testing: smoke testing with local models

### DIFF
--- a/bindings/node/examples/_common.mjs
+++ b/bindings/node/examples/_common.mjs
@@ -18,11 +18,29 @@ export function readArgs(defaultInput) {
   };
 }
 
-export async function loadClient(model, { embeddings = false } = {}) {
+export function readVisionArgs(defaultInput) {
+  const model = process.argv[2];
+  const projector = process.argv[3];
+  const image = process.argv[4];
+  if (!model || !projector || !image) {
+    console.error(
+      'usage: node examples/vision_chat.mjs <model.gguf> <projector.gguf> <image> [input]',
+    );
+    process.exit(2);
+  }
+  return {
+    model,
+    projector,
+    image,
+    input: process.argv.slice(5).join(' ') || defaultInput,
+  };
+}
+
+export async function loadClient(model, { embeddings = false, projectorPath = undefined } = {}) {
   setLlamaLogQuiet(true);
   console.log(`backend_before_load=${backendObservabilityJson(true)}`);
   const client = new CogentClient();
-  await client.addLocal('default', model, runtimeConfig({ embeddings }));
+  await client.addLocal('default', model, runtimeConfig({ embeddings, projectorPath }));
   console.log(`backend_after_load=${backendObservabilityJson(true)}`);
   return client;
 }
@@ -84,7 +102,8 @@ export function printEmbedding(result) {
   console.log(`preview=[${preview}]`);
 }
 
-function runtimeConfig({ embeddings }) {
+function runtimeConfig({ embeddings, projectorPath }) {
+  const multimodal = projectorPath == null ? {} : { projector_path: projectorPath };
   return {
     placement: {
       gpu_layers: gpuLayers(),
@@ -106,7 +125,7 @@ function runtimeConfig({ embeddings }) {
     cache: {
       mode: 'live_slot_prefix',
     },
-    multimodal: {},
+    multimodal,
     residency: {
       max_gpu_models_per_device: 1,
     },

--- a/bindings/node/examples/_common.mjs
+++ b/bindings/node/examples/_common.mjs
@@ -84,11 +84,11 @@ export function printText(result) {
   console.log(`text=${result.text.trim()}`);
   if (result.localStats) {
     console.log(
-      `metrics=ttft_ms:${result.localStats.ttftMs} ` +
-      `decode_ms:${result.localStats.decodeMs.toFixed(3)} ` +
+      `metrics=ttft_ms:${formatOptionalMetric(result.localStats.ttftMs)} ` +
+      `decode_ms:${formatOptionalMetric(result.localStats.decodeMs)} ` +
       `output_tokens:${result.localStats.outputTokens} ` +
-      `e2e_tps:${result.localStats.e2eTokensPerSecond} ` +
-      `decode_tps:${result.localStats.decodeTokensPerSecond}`
+      `e2e_tps:${formatOptionalMetric(result.localStats.e2eTokensPerSecond)} ` +
+      `decode_tps:${formatOptionalMetric(result.localStats.decodeTokensPerSecond)}`
     );
   }
 }
@@ -133,6 +133,10 @@ function runtimeConfig({ embeddings, projectorPath }) {
       runtime_metrics: true,
     },
   };
+}
+
+function formatOptionalMetric(value) {
+  return typeof value === 'number' ? value.toFixed(3) : 'n/a';
 }
 
 function gpuLayers() {

--- a/bindings/node/examples/vision_chat.mjs
+++ b/bindings/node/examples/vision_chat.mjs
@@ -1,0 +1,28 @@
+import { readFileSync } from 'node:fs';
+
+import { loadClient, printText, readVisionArgs, textOptions } from './_common.mjs';
+
+const { model, projector, image, input } = readVisionArgs('Describe this image in one sentence.');
+const client = await loadClient(model, { projectorPath: projector });
+const run = client.chat({
+  messages: [
+    { role: 'user', content: input },
+  ],
+  options: textOptions(),
+  local: {
+    contextKey: 'node-vision-chat-smoke',
+    media: [readFileSync(image)],
+  },
+  emitTokens: true,
+});
+let streamed = '';
+for await (const batch of run.tokens) {
+  process.stdout.write(batch.text);
+  streamed += batch.text;
+}
+process.stdout.write('\n');
+const result = await run.response;
+if (streamed !== result.text) {
+  throw new Error('streamed token batches did not match final response text');
+}
+printText(result);

--- a/bindings/node/src/lib.rs
+++ b/bindings/node/src/lib.rs
@@ -49,6 +49,9 @@ use serde::de::DeserializeOwned;
 #[cfg(test)]
 #[path = "tests/remote_tests.rs"]
 mod remote_tests;
+#[cfg(test)]
+#[path = "tests/stats_tests.rs"]
+mod stats_tests;
 
 type SharedCogentClient = Arc<Mutex<CoreClient>>;
 type SharedClientTextResponse = Arc<Mutex<Option<CoreClientTextResponseFuture>>>;
@@ -836,20 +839,33 @@ pub struct TokenUsage {
 
 #[napi(object)]
 pub struct RequestStats {
+    #[napi(js_name = "inputTokens")]
     pub input_tokens: i32,
+    #[napi(js_name = "outputTokens")]
     pub output_tokens: i32,
+    #[napi(js_name = "cacheMode")]
     pub cache_mode: String,
+    #[napi(js_name = "cacheSource")]
     pub cache_source: String,
+    #[napi(js_name = "cacheHits")]
     pub cache_hits: i32,
+    #[napi(js_name = "prefillTokens")]
     pub prefill_tokens: i32,
+    #[napi(js_name = "ttftMs")]
     pub ttft_ms: Option<f64>,
+    #[napi(js_name = "interTokenMs")]
     pub inter_token_ms: Option<f64>,
     #[napi(js_name = "e2eMs")]
     pub e2e_ms: Option<f64>,
+    #[napi(js_name = "e2eTokensPerSecond")]
     pub e2e_tokens_per_second: Option<f64>,
+    #[napi(js_name = "decodeTokensPerSecond")]
     pub decode_tokens_per_second: Option<f64>,
+    #[napi(js_name = "prefillTokensPerSecond")]
     pub prefill_tokens_per_second: Option<f64>,
+    #[napi(js_name = "prefillMs")]
     pub prefill_ms: f64,
+    #[napi(js_name = "decodeMs")]
     pub decode_ms: f64,
 }
 

--- a/bindings/node/src/tests/stats_tests.rs
+++ b/bindings/node/src/tests/stats_tests.rs
@@ -1,0 +1,17 @@
+//! Tests Node binding conversion for response stats exposed through N-API.
+
+use super::*;
+
+#[test]
+fn request_stats_map_tps_fields() {
+    let stats = request_stats_to_node(CoreRequestStats {
+        input_tokens: 1,
+        output_tokens: 2,
+        e2e_tokens_per_second: Some(40.0),
+        decode_tokens_per_second: Some(80.0),
+        ..CoreRequestStats::default()
+    });
+
+    assert_eq!(stats.e2e_tokens_per_second, Some(40.0));
+    assert_eq!(stats.decode_tokens_per_second, Some(80.0));
+}

--- a/bindings/python/examples/_common.py
+++ b/bindings/python/examples/_common.py
@@ -27,10 +27,32 @@ def read_args(default_input: str) -> tuple[str, str]:
     return sys.argv[1], " ".join(sys.argv[2:]) or default_input
 
 
-def load_client(model: str, *, embeddings: bool = False) -> CogentClient:
+def read_vision_args(default_input: str) -> tuple[str, str, str, str]:
+    if len(sys.argv) < 4:
+        raise SystemExit(
+            "usage: python examples/vision_chat.py <model.gguf> <projector.gguf> <image> [input]"
+        )
+    return (
+        sys.argv[1],
+        sys.argv[2],
+        sys.argv[3],
+        " ".join(sys.argv[4:]) or default_input,
+    )
+
+
+def load_client(
+    model: str,
+    *,
+    embeddings: bool = False,
+    projector_path: str | None = None,
+) -> CogentClient:
     set_llama_log_quiet(True)
     client = CogentClient()
-    client.add_local("default", model, runtime_config(embeddings=embeddings))
+    client.add_local(
+        "default",
+        model,
+        runtime_config(embeddings=embeddings, projector_path=projector_path),
+    )
     return client
 
 
@@ -89,7 +111,11 @@ def print_embedding(result: dict[str, object]) -> None:
     print(f"preview=[{preview}]")
 
 
-def runtime_config(*, embeddings: bool) -> NativeRuntimeConfig:
+def runtime_config(
+    *,
+    embeddings: bool,
+    projector_path: str | None = None,
+) -> NativeRuntimeConfig:
     return NativeRuntimeConfig(
         placement=ModelPlacementConfig(gpu_layers=gpu_layers()),
         context=ContextRuntimeConfig(
@@ -109,7 +135,7 @@ def runtime_config(*, embeddings: bool) -> NativeRuntimeConfig:
         cache=CacheRuntimeConfig(
             mode="live_slot_prefix",
         ),
-        multimodal=MultimodalRuntimeConfig(),
+        multimodal=MultimodalRuntimeConfig(projector_path=projector_path),
         residency=ResidencyRuntimeConfig(max_gpu_models_per_device=1),
         observability=ObservabilityRuntimeConfig(runtime_metrics=True),
     )

--- a/bindings/python/examples/vision_chat.py
+++ b/bindings/python/examples/vision_chat.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from cogentlm import ChatMessage, LocalTextOptions
+
+from _common import load_client, print_text, read_vision_args, text_options
+
+
+def main() -> None:
+    model, projector, image, prompt = read_vision_args("Describe this image in one sentence.")
+    client = load_client(model, projector_path=projector)
+    run = client.chat(
+        [
+            ChatMessage("user", prompt),
+        ],
+        options=text_options(),
+        local=LocalTextOptions(
+            context_key="python-vision-chat-smoke",
+            media=[Path(image).read_bytes()],
+        ),
+        emit_tokens=True,
+    )
+    streamed = ""
+    for batch in run.tokens():
+        print(batch["text"], end="", flush=True)
+        streamed += batch["text"]
+    print()
+    result = run.result()
+    if streamed != result["text"]:
+        raise RuntimeError("streamed token batches did not match final response text")
+    print_text(result)
+
+
+if __name__ == "__main__":
+    main()

--- a/crates/client/examples/local_common/mod.rs
+++ b/crates/client/examples/local_common/mod.rs
@@ -1,5 +1,3 @@
-#![allow(dead_code)]
-
 use std::env;
 use std::path::PathBuf;
 

--- a/crates/client/examples/local_common/mod.rs
+++ b/crates/client/examples/local_common/mod.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 use std::env;
 use std::path::PathBuf;
 
@@ -13,6 +15,13 @@ pub type ExampleResult<T> = Result<T, Box<dyn std::error::Error>>;
 
 pub struct ExampleArgs {
     pub model_path: PathBuf,
+    pub input: String,
+}
+
+pub struct VisionExampleArgs {
+    pub model_path: PathBuf,
+    pub projector_path: PathBuf,
+    pub image_path: PathBuf,
     pub input: String,
 }
 
@@ -35,16 +44,64 @@ pub fn args(default_input: &'static str) -> ExampleResult<ExampleArgs> {
     })
 }
 
+pub fn vision_args(default_input: &'static str) -> ExampleResult<VisionExampleArgs> {
+    let mut args = env::args().skip(1);
+    let model_path = args.next().ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "usage: cargo run -p cogentlm-client --example vision_chat -- \
+             <model.gguf> <projector.gguf> <image> [input]",
+        )
+    })?;
+    let projector_path = args.next().ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "usage: cargo run -p cogentlm-client --example vision_chat -- \
+             <model.gguf> <projector.gguf> <image> [input]",
+        )
+    })?;
+    let image_path = args.next().ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "usage: cargo run -p cogentlm-client --example vision_chat -- \
+             <model.gguf> <projector.gguf> <image> [input]",
+        )
+    })?;
+    let input = args.collect::<Vec<_>>().join(" ");
+    Ok(VisionExampleArgs {
+        model_path: PathBuf::from(model_path),
+        projector_path: PathBuf::from(projector_path),
+        image_path: PathBuf::from(image_path),
+        input: if input.is_empty() {
+            default_input.to_string()
+        } else {
+            input
+        },
+    })
+}
+
 pub async fn load_client(model_path: PathBuf, embeddings: bool) -> ExampleResult<CogentClient> {
+    load_client_with_projector(model_path, None, embeddings).await
+}
+
+pub async fn load_client_with_projector(
+    model_path: PathBuf,
+    projector_path: Option<PathBuf>,
+    embeddings: bool,
+) -> ExampleResult<CogentClient> {
     set_llama_log_quiet(true);
     let mut client = CogentClient::new();
     client
-        .add_local("default", model_path, runtime_config(embeddings))
+        .add_local(
+            "default",
+            model_path,
+            runtime_config(embeddings, projector_path),
+        )
         .await?;
     Ok(client)
 }
 
-fn runtime_config(embeddings: bool) -> NativeRuntimeConfig {
+fn runtime_config(embeddings: bool, projector_path: Option<PathBuf>) -> NativeRuntimeConfig {
     NativeRuntimeConfig {
         placement: ModelPlacementConfig {
             gpu_layers: env_parse("COGENTLM_GPU_LAYERS")
@@ -73,7 +130,10 @@ fn runtime_config(embeddings: bool) -> NativeRuntimeConfig {
             mode: KvReuseMode::LiveSlotPrefix,
             ..Default::default()
         },
-        multimodal: MultimodalRuntimeConfig::default(),
+        multimodal: MultimodalRuntimeConfig {
+            projector_path: projector_path.map(|path| path.to_string_lossy().into_owned()),
+            ..Default::default()
+        },
         residency: ResidencyRuntimeConfig {
             max_gpu_models_per_device: 1,
             ..Default::default()

--- a/crates/client/examples/vision_chat.rs
+++ b/crates/client/examples/vision_chat.rs
@@ -1,0 +1,68 @@
+mod local_common;
+
+use std::fs;
+
+use cogentlm_client::{CogentChatRequest, CogentTextOptions, CogentTextResponse, LocalTextOptions};
+use cogentlm_engine::engine::{ChatMessage, ChatRole};
+use futures::executor::block_on;
+use futures::StreamExt;
+
+fn main() -> local_common::ExampleResult<()> {
+    block_on(async {
+        let args = local_common::vision_args("Describe this image in one sentence.")?;
+        let image = fs::read(args.image_path)?;
+        let client = local_common::load_client_with_projector(
+            args.model_path,
+            Some(args.projector_path),
+            false,
+        )
+        .await?;
+        let run = client.chat(CogentChatRequest {
+            messages: vec![ChatMessage::new(ChatRole::User, args.input)],
+            options: text_options(),
+            local: LocalTextOptions {
+                context_key: Some("rust-vision-chat-smoke".to_string()),
+                media: vec![image],
+                ..Default::default()
+            },
+            emit_tokens: true,
+            ..Default::default()
+        });
+        let (mut tokens, response) = run.into_parts();
+        let mut streamed = String::new();
+        while let Some(batch) = tokens.next().await {
+            print!("{}", batch.text);
+            streamed.push_str(&batch.text);
+        }
+        println!();
+        let response = response.await?;
+        assert_eq!(streamed, response.text);
+        print_text(response);
+        Ok(())
+    })
+}
+
+fn text_options() -> CogentTextOptions {
+    CogentTextOptions {
+        max_tokens: local_common::env_parse("COGENTLM_MAX_TOKENS"),
+        temperature: local_common::env_parse("COGENTLM_TEMPERATURE"),
+        top_p: local_common::env_parse("COGENTLM_TOP_P"),
+        stop: Vec::new(),
+    }
+}
+
+fn print_text(response: CogentTextResponse) {
+    println!("endpoint={:?}", response.endpoint);
+    println!("finish_reason={}", response.finish_reason.as_str());
+    println!("text={}", response.text.trim());
+    if let Some(stats) = response.local_stats {
+        println!(
+            "metrics=ttft_ms:{:?} decode_ms:{:.3} output_tokens:{} e2e_tps:{:?} decode_tps:{:?}",
+            stats.ttft_ms,
+            stats.decode_ms,
+            stats.output_tokens,
+            stats.e2e_tokens_per_second,
+            stats.decode_tokens_per_second
+        );
+    }
+}

--- a/crates/gateway/examples/remote_smoke_gateway.toml
+++ b/crates/gateway/examples/remote_smoke_gateway.toml
@@ -1,0 +1,90 @@
+[server]
+bind = "127.0.0.1:8787"
+
+[auth]
+token_env = "COGENTLM_GATEWAY_TOKEN"
+
+[limits]
+max_request_bytes = 1048576
+
+[cors]
+allowed_origins = ["http://localhost:5173"]
+
+# Provider credentials stay in the gateway process environment:
+# OPENAI_API_KEY, ANTHROPIC_API_KEY, and GEMINI_API_KEY.
+#
+# Keep chat/query and embedding aliases separate. Embedding requests must use
+# embedding-capable upstream models.
+
+[[aliases]]
+name = "openai-chat"
+operations = ["chat"]
+
+[aliases.limits]
+max_concurrent_requests = 8
+max_requests_per_minute = 120
+
+[aliases.backend]
+kind = "open_ai"
+model = "gpt-5-mini"
+api_key_env = "OPENAI_API_KEY"
+
+[[aliases]]
+name = "openai-embed"
+operations = ["embed"]
+
+[aliases.limits]
+max_concurrent_requests = 8
+max_requests_per_minute = 120
+
+[aliases.backend]
+kind = "open_ai"
+model = "text-embedding-3-small"
+api_key_env = "OPENAI_API_KEY"
+
+[[aliases]]
+name = "anthropic-text"
+operations = ["query", "chat"]
+
+[aliases.limits]
+max_concurrent_requests = 8
+max_requests_per_minute = 120
+
+[aliases.backend]
+kind = "anthropic"
+model = "claude-sonnet-4-5"
+api_key_env = "ANTHROPIC_API_KEY"
+
+[[aliases]]
+name = "gemini-chat"
+operations = ["chat"]
+
+[aliases.limits]
+max_concurrent_requests = 8
+max_requests_per_minute = 120
+
+[aliases.backend]
+kind = "open_ai_compatible"
+model = "gemini-2.5-flash"
+base_url = "https://generativelanguage.googleapis.com/v1beta/openai/"
+
+[aliases.backend.auth]
+kind = "bearer"
+token_env = "GEMINI_API_KEY"
+
+[[aliases]]
+name = "gemini-embed"
+operations = ["embed"]
+
+[aliases.limits]
+max_concurrent_requests = 8
+max_requests_per_minute = 120
+
+[aliases.backend]
+kind = "open_ai_compatible"
+model = "gemini-embedding-001"
+base_url = "https://generativelanguage.googleapis.com/v1beta/openai/"
+
+[aliases.backend.auth]
+kind = "bearer"
+token_env = "GEMINI_API_KEY"

--- a/crates/gateway/src/tests/config_tests.rs
+++ b/crates/gateway/src/tests/config_tests.rs
@@ -859,6 +859,7 @@ fn gateway_example_configs_parse() {
         "openai_compatible_gateway.toml",
         "openai_gateway.toml",
         "anthropic_gateway.toml",
+        "remote_smoke_gateway.toml",
     ] {
         let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
             .join("examples")


### PR DESCRIPTION
Run smoke testing with the shell script like below. All compiled and passed without issues. 

  ```
  $QWEN = ".\Qwen3.5-0.8B-Q4_0.gguf"
  $T5 = ".\t5-small-f16.gguf"
  $MINICPM = ".\MiniCPM-V-4.6-Q8_0.gguf"
  $MMPROJ = ".\mmproj-MiniCPM-V-4.6-Q8_0.gguf"
  $GTE = ".\gte-small-q8_0.gguf"
  $IMG = ".\test.png"

  $CHAT = "Answer in one short sentence: what is local inference?"
  $VISION = "Describe this image in one sentence."
  $QUERY = "translate English to German: The house is wonderful."
  $EMBED = "CogentLM embedding smoke input."

  $env:COGENTLM_MAX_TOKENS = "32"
  $env:COGENTLM_TEMPERATURE = "0"
  $env:COGENTLM_SEED = "42"

  CPU

  cargo xtask build node --backend cpu
  cargo xtask build python --backend cpu

  $env:COGENTLM_NODE_BACKEND = "cpu"
  $env:COGENTLM_PYTHON_BACKEND = "cpu"
  $env:COGENTLM_GPU_LAYERS = "0"

  cargo run -p cogentlm-client --example chat -- $QWEN $CHAT
  cargo run -p cogentlm-client --example vision_chat -- $MINICPM
  $MMPROJ $IMG $VISION
  cargo run -p cogentlm-client --example query -- $T5 $QUERY
  cargo run -p cogentlm-client --example embed -- $GTE $EMBED

  node .\bindings\node\examples\chat.mjs $QWEN $CHAT
  node .\bindings\node\examples\vision_chat.mjs $MINICPM $MMPROJ $IMG
  $VISION
  node .\bindings\node\examples\query.mjs $T5 $QUERY
  node .\bindings\node\examples\embed.mjs $GTE $EMBED

  $PY = ".\bindings\python\.venv\Scripts\python.exe"
  & $PY .\bindings\python\examples\chat.py $QWEN $CHAT
  & $PY .\bindings\python\examples\vision_chat.py $MINICPM $MMPROJ
  $IMG $VISION
  & $PY .\bindings\python\examples\query.py $T5 $QUERY
  & $PY .\bindings\python\examples\embed.py $GTE $EMBED

  GPU

  $BACKEND = "vulkan"   # or cuda / metal where supported

  cargo xtask build node --backend $BACKEND
  cargo xtask build python --backend $BACKEND

  $env:COGENTLM_NODE_BACKEND = $BACKEND
  $env:COGENTLM_PYTHON_BACKEND = $BACKEND
  $env:COGENTLM_GPU_LAYERS = "-1"

  cargo run -p cogentlm-client --features $BACKEND --example chat --
  $QWEN $CHAT
  cargo run -p cogentlm-client --features $BACKEND --example
  vision_chat -- $MINICPM $MMPROJ $IMG $VISION
  cargo run -p cogentlm-client --features $BACKEND --example query --
  $T5 $QUERY
  cargo run -p cogentlm-client --features $BACKEND --example embed --
  $GTE $EMBED

  node .\bindings\node\examples\chat.mjs $QWEN $CHAT
  node .\bindings\node\examples\vision_chat.mjs $MINICPM $MMPROJ $IMG
  $VISION
  node .\bindings\node\examples\query.mjs $T5 $QUERY
  node .\bindings\node\examples\embed.mjs $GTE $EMBED

  & $PY .\bindings\python\examples\chat.py $QWEN $CHAT
  & $PY .\bindings\python\examples\vision_chat.py $MINICPM $MMPROJ
  $IMG $VISION
  & $PY .\bindings\python\examples\query.py $T5 $QUERY
  & $PY .\bindings\python\examples\embed.py $GTE $EMBED
```