### PR TITLE
llama: sync with upstream

### DIFF
--- a/crates/sys/cmake/llama_mtmd_sources.cmake
+++ b/crates/sys/cmake/llama_mtmd_sources.cmake
@@ -30,10 +30,14 @@ set(SHARED_MTMD_SOURCES
     ${SIPP_MTMD_MODEL_DIR}/cogvlm.cpp
     ${SIPP_MTMD_MODEL_DIR}/conformer.cpp
     ${SIPP_MTMD_MODEL_DIR}/dotsocr.cpp
+    ${SIPP_MTMD_MODEL_DIR}/exaone4_5.cpp
     ${SIPP_MTMD_MODEL_DIR}/gemma4a.cpp
     ${SIPP_MTMD_MODEL_DIR}/gemma4v.cpp
+    ${SIPP_MTMD_MODEL_DIR}/gemma4ua.cpp
+    ${SIPP_MTMD_MODEL_DIR}/gemma4uv.cpp
     ${SIPP_MTMD_MODEL_DIR}/glm4v.cpp
     ${SIPP_MTMD_MODEL_DIR}/granite-speech.cpp
+    ${SIPP_MTMD_MODEL_DIR}/granite4-vision.cpp
     ${SIPP_MTMD_MODEL_DIR}/hunyuanvl.cpp
     ${SIPP_MTMD_MODEL_DIR}/internvl.cpp
     ${SIPP_MTMD_MODEL_DIR}/kimivl.cpp

--- a/crates/sys/native/llama_shim/sipp_shim.cpp
+++ b/crates/sys/native/llama_shim/sipp_shim.cpp
@@ -55,6 +55,7 @@ struct sipp_mtmd_context {
 
 struct sipp_mtmd_bitmap {
     mtmd_bitmap * inner;
+    mtmd_helper_video * video_inner;
 };
 
 struct sipp_mtmd_input_chunks {
@@ -135,7 +136,7 @@ void apply_sampling_json(
                 }
                 names.push_back(std::move(name));
             }
-            sampling.samplers = common_sampler_types_from_names(names, true);
+            sampling.samplers = common_sampler_types_from_names(names);
         }
 
         set_if_present(parsed, "seed", sampling.seed);
@@ -1132,12 +1133,14 @@ sipp_mtmd_bitmap * sipp_mtmd_bitmap_init_from_buf(
         return nullptr;
     }
 
-    mtmd_bitmap * inner = mtmd_helper_bitmap_init_from_buf(context->inner, data, len);
-    if (inner == nullptr) {
+    const mtmd_helper_bitmap_wrapper inner =
+        mtmd_helper_bitmap_init_from_buf(context->inner, data, len, false);
+    if (inner.bitmap == nullptr) {
         return nullptr;
     }
     auto * bitmap = new sipp_mtmd_bitmap();
-    bitmap->inner = inner;
+    bitmap->inner = inner.bitmap;
+    bitmap->video_inner = inner.video_ctx;
     return bitmap;
 }
 
@@ -1147,6 +1150,9 @@ void sipp_mtmd_bitmap_free(sipp_mtmd_bitmap * bitmap) {
     }
     if (bitmap->inner != nullptr) {
         mtmd_bitmap_free(bitmap->inner);
+    }
+    if (bitmap->video_inner != nullptr) {
+        mtmd_helper_video_free(bitmap->video_inner);
     }
     delete bitmap;
 }


### PR DESCRIPTION
This PR syncs with upstream llama.cpp to resolve an issue in #58 for incompatible shader extensions between chrome and firefox. 