### PR TITLE
Update bowser runtime selection and Firefox WASM behavior

### DIFF
--- a/demos/sipp-dist-watch.ts
+++ b/demos/sipp-dist-watch.ts
@@ -37,7 +37,7 @@ const sippClientArtifactDir = path.join(
 const sippClientSrcDir = path.join(sippClientPackageDir, 'src');
 const sippClientWasmDir = path.join(sippClientArtifactDir, 'dist', 'wasm');
 const sourceFilePattern = /\.tsx?$/;
-const wasmArtifactPattern = /sipp-wasm(?:-pthread)?(?:-cpu-nojspi)?\.(?:js|wasm)$/;
+const wasmArtifactPattern = /sipp-wasm-pthread(?:-cpu-nojspi)?\.(?:js|wasm)$/;
 const rebuildArgs = ['run', '--filter=@noumena-labs/sipp', 'build:ts'];
 
 function isSippClientSourceFile(filePath: string): boolean {

--- a/docs/en/guides/local-inference.md
+++ b/docs/en/guides/local-inference.md
@@ -63,9 +63,10 @@ Browser execution has two separate choices:
 - `wasmThreading: 'pthread'` enables the pthread WASM runtime and requires
   `SharedArrayBuffer` plus cross-origin isolation headers.
 
-Use `wasmThreading: 'single-thread'` when the app cannot serve COOP/COEP
-headers. Use `executionMode: 'main-thread'` mainly for debugging or constrained
-hosts.
+The bundled browser runtime requires COOP/COEP headers. Apps that cannot serve
+those headers must set `wasmThreading: 'single-thread'` and provide custom
+single-thread `moduleUrl` and `wasmUrl` assets. Use
+`executionMode: 'main-thread'` mainly for debugging or constrained hosts.
 
 Native Node.js, Python, and Rust local endpoints can tune CPU thread counts
 with `context.n_threads` and `context.n_threads_batch`. Leave them unset for

--- a/docs/en/packages/browser.md
+++ b/docs/en/packages/browser.md
@@ -101,15 +101,20 @@ gateway tokens in browser bundles.
 
 The browser runtime links Sipp's Rust WASM ABI with llama.cpp and ggml
 through Emscripten. It runs GGUF text and vision models with WebGPU when the
-browser exposes a compatible adapter, and falls back to CPU execution for
-compatible local workflows. OPFS-backed model caching keeps repeated browser
-loads local after the first model fetch or file import.
+browser exposes the required adapter, or with CPU execution when CPU is the
+selected backend. OPFS-backed model caching keeps repeated browser loads local
+after the first model fetch or file import.
 
 The package resolves its packaged JavaScript and WASM assets at runtime. Most
 apps should not override asset URLs. Use `executionMode`, `wasmThreading`,
 `browserCache`, and local endpoint `options.runtime` only when the application
 needs explicit control over browser execution, storage, or local runtime
 behavior.
+
+Packaged browser runtime assets use pthreads, so browser-local inference needs
+`SharedArrayBuffer` and cross-origin isolation headers. Hosts that cannot serve
+those headers must set `wasmThreading: 'single-thread'` and provide custom
+single-thread `moduleUrl` and `wasmUrl` assets.
 
 See [Runtime Options](../reference/runtime-options.md) for `SippClient`
 options, WebGPU/backend selection, worker mode, pthread requirements, and

--- a/docs/en/packages/frameworks/nextjs.md
+++ b/docs/en/packages/frameworks/nextjs.md
@@ -182,10 +182,12 @@ export function LocalChat(): JSX.Element {
 }
 ```
 
-If you override `moduleUrl`, `wasmUrl`, `pthreadModuleUrl`, or
-`pthreadWasmUrl`, provide both the JavaScript and WASM asset URLs for the
-selected runtime. Use `wasmThreading: 'pthread'` only when the app is served
-with cross-origin isolation headers that enable `SharedArrayBuffer`.
+Override runtime assets with `moduleUrl` and `wasmUrl`; provide both the
+JavaScript and WASM asset URLs for the selected runtime. The packaged browser
+runtime uses pthreads, so browser-local inference requires cross-origin
+isolation headers that enable `SharedArrayBuffer`. Apps that cannot serve
+those headers must provide custom single-thread assets with
+`wasmThreading: 'single-thread'`, `moduleUrl`, and `wasmUrl`.
 
 ## Hybrid Client Component
 

--- a/docs/en/packages/frameworks/vite-react.md
+++ b/docs/en/packages/frameworks/vite-react.md
@@ -58,15 +58,15 @@ export function LocalQuery(): JSX.Element {
 }
 ```
 
-Omit `backend` to let the browser runtime choose a compatible backend. Use
+Omit `backend` to let the browser runtime choose the backend. Use
 `backend: 'webgpu'` when the UI should explicitly request WebGPU and surface
-errors or fallbacks itself.
+backend errors itself.
 
 ## Local Development Headers
 
-The pthread WASM runtime requires `SharedArrayBuffer` and cross-origin
-isolation. Configure Vite dev and preview headers before using
-`wasmThreading: 'pthread'`:
+The packaged WASM runtime uses pthreads and requires `SharedArrayBuffer` plus
+cross-origin isolation. Configure Vite dev and preview headers before using the
+default browser runtime:
 
 ```ts
 // vite.config.ts
@@ -88,8 +88,9 @@ export default defineConfig({
 });
 ```
 
-Use `wasmThreading: 'single-thread'` when the app cannot serve those headers.
-Use `executionMode: 'main-thread'` only for debugging or constrained hosts.
+Apps that cannot serve those headers must provide custom single-thread
+assets with `wasmThreading: 'single-thread'`, `moduleUrl`, and `wasmUrl`. Use
+`executionMode: 'main-thread'` only for debugging or constrained hosts.
 
 ## Runtime Asset Overrides
 
@@ -102,13 +103,14 @@ assets:
 
 ```ts
 const client = new SippClient({
-  moduleUrl: '/assets/sipp-wasm.js',
-  wasmUrl: '/assets/sipp-wasm.wasm',
+  moduleUrl: '/assets/sipp-wasm-pthread.js',
+  wasmUrl: '/assets/sipp-wasm-pthread.wasm',
 });
 ```
 
-When overriding assets, provide both `moduleUrl` and `wasmUrl`. For pthread
-runtime assets, provide both `pthreadModuleUrl` and `pthreadWasmUrl`.
+`moduleUrl` and `wasmUrl` override the selected runtime. The selected runtime
+defaults to pthread. Custom single-thread builds must also set
+`wasmThreading: 'single-thread'`.
 
 ## Model Files And Cache
 

--- a/docs/en/reference/device-support.md
+++ b/docs/en/reference/device-support.md
@@ -130,7 +130,7 @@ function supportsWasmPthreads(): boolean {
 
 Single-thread artifacts are not included in the default browser package. Hosts
 that cannot serve COOP/COEP headers must provide a custom single-thread
-`moduleUrl` and `wasmUrl`.
+runtime with `wasmThreading: 'single-thread'`, `moduleUrl`, and `wasmUrl`.
 
 ---
 
@@ -224,8 +224,8 @@ experimental JSPI support enabled, the JSPI runtime path was functional: models
 loaded and generated tokens. It was not performant enough to ship. The Firefox
 browser runtime uses the pthread CPU no-JSPI artifact.
 
-This is a browser-runtime routing decision, not a single-thread fallback. The
-Firefox path still requires `SharedArrayBuffer`, workers, and COOP/COEP headers.
+The Firefox browser path is pthread CPU no-JSPI. It still requires
+`SharedArrayBuffer`, workers, and COOP/COEP headers.
 
 ---
 

--- a/docs/en/reference/runtime-options.md
+++ b/docs/en/reference/runtime-options.md
@@ -27,21 +27,21 @@ and browser storage. They do not select a model by themselves.
 | Option | Use |
 | --- | --- |
 | `executionMode` | `auto` uses a worker when available. `worker` forces worker transport. `main-thread` is useful for debugging or constrained hosts. |
-| `wasmThreading` | `single-thread` loads the single-thread WASM runtime. `pthread` loads the pthread runtime. |
-| `moduleUrl`, `wasmUrl` | Override single-thread runtime asset URLs when a bundler or deployment moves package assets. Provide both together. |
-| `pthreadModuleUrl`, `pthreadWasmUrl` | Override pthread runtime asset URLs. Provide both together. |
+| `wasmThreading` | `pthread` loads the bundled pthread runtime. `single-thread` is only valid with explicit custom `moduleUrl` and `wasmUrl` assets. |
+| `moduleUrl`, `wasmUrl` | Override the selected runtime asset URLs. Provide both together. |
 | `browserCache` | Tune OPFS split thresholds and direct-load behavior for browser GGUF storage. |
 | `trustedOrigins` | Allow runtime asset URLs from additional origins. Defaults allow same-origin package assets. |
 | `workerUrl` | Override the worker entry URL when the bundler cannot resolve the packaged worker. |
 
-`wasmThreading: 'pthread'` requires `SharedArrayBuffer`, cross-origin
-isolation, and COOP/COEP headers. Use `single-thread` when the application
-cannot serve those headers.
+The bundled browser runtime requires `SharedArrayBuffer`, cross-origin
+isolation, and COOP/COEP headers. Applications that cannot serve those headers
+must set `wasmThreading: 'single-thread'` and provide custom single-thread
+assets with `moduleUrl` and `wasmUrl`.
 
 ```ts
 const client = new SippClient({
   executionMode: 'worker',
-  wasmThreading: 'single-thread',
+  wasmThreading: 'pthread',
 });
 ```
 

--- a/docs/en/sipp/commands.md
+++ b/docs/en/sipp/commands.md
@@ -75,7 +75,7 @@ sipp test list --group unit --layer interface --cases --search router --format j
 sipp test unit group full
 sipp test unit suite rust-crates --package sipp-rs
 sipp test unit suite node-package --backend cpu
-sipp test unit suite browser --wasm-threading single-thread
+sipp test unit suite browser --wasm-threading pthread
 sipp test smoke suite example-node --backend cpu
 sipp test smoke group local-model --backend cpu
 sipp test verify --changed

--- a/docs/en/testing.md
+++ b/docs/en/testing.md
@@ -22,8 +22,8 @@ cargo xtask test unit group whitebox
 cargo xtask test unit group interface
 cargo xtask test unit suite xtask
 cargo xtask test unit suite rust-crates --package sipp-rs
-cargo xtask test unit suite browser --wasm-threading single-thread
-cargo xtask test unit suite demos --wasm-threading single-thread
+cargo xtask test unit suite browser --wasm-threading pthread
+cargo xtask test unit suite demos --wasm-threading pthread
 cargo xtask test unit suite node-package --backend cpu
 cargo xtask test unit suite python-package --backend cpu
 cargo xtask test smoke suite example-node --backend cpu
@@ -67,9 +67,10 @@ Unit suite names expose suite-specific options, such as
 | `cargo xtask test unit group interface` | `api`, `cli`, `node-package`, and `python-package` |
 | `cargo xtask test unit group full` | Every deterministic unit suite |
 
-Browser and demo unit suites accept `--wasm-threading single-thread|pthread|all`.
-CI uses `single-thread` to keep source validation fast. Release package builds
-continue to use `cargo xtask build wasm`, whose default is `all`.
+Browser and demo unit suites accept `--wasm-threading single-thread|pthread|all`
+for explicit compatibility testing. The default is `pthread`, matching the
+bundled browser package. Release package builds use `cargo xtask build wasm`,
+which stages the pthread WebGPU+JSPI and pthread CPU non-JSPI artifacts.
 
 `test smoke` owns holistic integration checks. It is split into explicit
 namespaces:

--- a/docs/zh/guides/local-inference.md
+++ b/docs/zh/guides/local-inference.md
@@ -46,7 +46,7 @@ Node.js、Python、Rust 和 CLI 的本地端点使用文件系统路径。通过
 - `executionMode: 'worker'` 或 `auto`：环境支持 Worker 时，将推理计算移出 UI 主线程。
 - `wasmThreading: 'pthread'`：启用多线程 WASM 运行时，需浏览器支持 `SharedArrayBuffer` 并配置跨源隔离响应头。
 
-应用无法提供 COOP/COEP 响应头时，使用 `wasmThreading: 'single-thread'`。`executionMode: 'main-thread'` 通常仅用于调试或受限宿主环境。
+内置浏览器运行时要求提供 COOP/COEP 响应头。应用无法提供这些响应头时，需要设置 `wasmThreading: 'single-thread'`，并提供自定义单线程 `moduleUrl` 和 `wasmUrl` 资源。`executionMode: 'main-thread'` 通常仅用于调试或受限宿主环境。
 
 原生 Node.js、Python 和 Rust 端点可通过 `context.n_threads` 和 `context.n_threads_batch` 手动指定 CPU 线程数。除非有确切性能数据，否则建议留空使用默认值。
 

--- a/docs/zh/packages/browser.md
+++ b/docs/zh/packages/browser.md
@@ -89,9 +89,11 @@ const run = client.chat(messages, {
 
 ## 浏览器运行时选项
 
-浏览器运行时通过 Emscripten 将 Sipp 的 Rust WASM ABI 与 llama.cpp 及 ggml 连接起来。浏览器支持兼容适配器时，引擎优先使用 WebGPU 运行 GGUF 文本和视觉模型；WebGPU 不可用时自动回退到 CPU。首次下载模型或导入文件后，基于 OPFS 的模型缓存可加速后续加载。
+浏览器运行时通过 Emscripten 将 Sipp 的 Rust WASM ABI 与 llama.cpp 及 ggml 连接起来。浏览器暴露所需适配器时，引擎使用 WebGPU 运行 GGUF 文本和视觉模型；选择 CPU 后端时则使用 CPU 执行。首次下载模型或导入文件后，基于 OPFS 的模型缓存可加速后续加载。
 
 该包在运行时自动解析其打包的 JavaScript 和 WASM 资源，通常无需手动覆盖资源 URL。只有应用需要精细控制浏览器的执行、存储或本地运行时行为时，才需要配置 `executionMode`、`wasmThreading`、`browserCache` 以及本地端点的 `options.runtime`。
+
+打包提供的浏览器运行时使用 pthread，因此浏览器本地推理需要 `SharedArrayBuffer` 与跨源隔离响应头。无法提供这些响应头的宿主必须设置 `wasmThreading: 'single-thread'`，并提供自定义单线程 `moduleUrl` 和 `wasmUrl` 资源。
 
 `SippClient` 选项、WebGPU 和后端选择、Worker 模式、pthread 要求及本地运行时配置组的详情，见[运行时选项](../reference/runtime-options.md)。
 

--- a/docs/zh/packages/frameworks/nextjs.md
+++ b/docs/zh/packages/frameworks/nextjs.md
@@ -165,7 +165,7 @@ export function LocalChat(): JSX.Element {
 }
 ```
 
-如果覆盖了默认的资源路径（`moduleUrl`、`wasmUrl`、`pthreadModuleUrl` 或 `pthreadWasmUrl`），请务必成对提供对应运行时的 JavaScript 和 WASM 资源 URL。并且，只有在应用正确配置了跨源隔离头并开启 `SharedArrayBuffer` 支持的情况下，才能设置 `wasmThreading: 'pthread'`。
+使用 `moduleUrl` 和 `wasmUrl` 覆盖运行时资源时，请务必成对提供当前选择运行时的 JavaScript 和 WASM 资源 URL。打包提供的浏览器运行时使用 pthread，因此浏览器本地推理需要配置跨源隔离头并开启 `SharedArrayBuffer`。无法提供这些响应头的应用必须设置 `wasmThreading: 'single-thread'`，并提供自定义单线程 `moduleUrl` 和 `wasmUrl` 资源。
 
 ## 混合模式客户端组件
 

--- a/docs/zh/packages/frameworks/vite-react.md
+++ b/docs/zh/packages/frameworks/vite-react.md
@@ -52,11 +52,11 @@ export function LocalQuery(): JSX.Element {
 }
 ```
 
-省略 `backend` 时，浏览器运行时会自动选择最合适的后端引擎。如果 UI 需要强制 WebGPU 并由应用层处理错误及回退，请显式设置 `backend: 'webgpu'`。
+省略 `backend` 时，浏览器运行时会选择后端引擎。如果 UI 需要明确请求 WebGPU 并由应用层处理后端错误，请显式设置 `backend: 'webgpu'`。
 
 ## Vite 配置
 
-pthread 支持的 WASM 运行时必须依赖 `SharedArrayBuffer` 和跨源隔离。开启 `wasmThreading: 'pthread'` 前，先配置 Vite 的开发与预览服务器请求头：
+打包提供的 WASM 运行时使用 pthread，必须依赖 `SharedArrayBuffer` 和跨源隔离。使用默认浏览器运行时前，先配置 Vite 的开发与预览服务器请求头：
 
 ```ts
 // vite.config.ts
@@ -78,7 +78,7 @@ export default defineConfig({
 });
 ```
 
-应用无法配置这些响应头时，设置 `wasmThreading: 'single-thread'`。仅在调试或受限主机环境中使用 `executionMode: 'main-thread'`。
+应用无法配置这些响应头时，需要设置 `wasmThreading: 'single-thread'`，并提供自定义单线程 `moduleUrl` 和 `wasmUrl` 资源。仅在调试或受限主机环境中使用 `executionMode: 'main-thread'`。
 
 ## 运行时资源覆盖
 
@@ -88,12 +88,12 @@ export default defineConfig({
 
 ```ts
 const client = new SippClient({
-  moduleUrl: '/assets/sipp-wasm.js',
-  wasmUrl: '/assets/sipp-wasm.wasm',
+  moduleUrl: '/assets/sipp-wasm-pthread.js',
+  wasmUrl: '/assets/sipp-wasm-pthread.wasm',
 });
 ```
 
-覆盖资源时必须成对提供 `moduleUrl` 和 `wasmUrl`。pthread 运行时需同时提供 `pthreadModuleUrl` 和 `pthreadWasmUrl`。
+`moduleUrl` 和 `wasmUrl` 覆盖当前选择的运行时。默认选择 pthread。自定义单线程构建还必须设置 `wasmThreading: 'single-thread'`。
 
 ## 模型文件与缓存
 

--- a/docs/zh/reference/device-support.md
+++ b/docs/zh/reference/device-support.md
@@ -125,7 +125,7 @@ function supportsWasmPthreads(): boolean {
 }
 ```
 
-默认浏览器包不包含单线程产物。托管环境（如 GitHub Pages 或无法控制响应头的共享主机）无法返回 COOP/COEP 响应头时，需要提供自定义的单线程 `moduleUrl` 和 `wasmUrl`。
+默认浏览器包不包含单线程产物。托管环境（如 GitHub Pages 或无法控制响应头的共享主机）无法返回 COOP/COEP 响应头时，需要设置 `wasmThreading: 'single-thread'`，并提供自定义单线程 `moduleUrl` 和 `wasmUrl`。
 
 ---
 
@@ -216,7 +216,7 @@ WebGPU 和 `shader-f16` 能力。启用 Firefox 的实验性 JSPI 后，JSPI 运
 路径可以正常工作：模型可以加载并生成 token。但该路径性能不足以作为发布
 路径。因此 Firefox 浏览器运行时选择 pthread CPU no-JSPI 产物。
 
-这是浏览器运行时路由决策，不是单线程 fallback。Firefox 路径仍然需要
+Firefox 浏览器路径是 pthread CPU no-JSPI。该路径仍然需要
 `SharedArrayBuffer`、Worker，以及 COOP/COEP 响应头。
 
 ---

--- a/docs/zh/reference/runtime-options.md
+++ b/docs/zh/reference/runtime-options.md
@@ -22,9 +22,8 @@ Python 和 Rust 通过各语言自己的描述符和配置类/结构体提供相
 | 选项 | 说明 |
 | --- | --- |
 | `executionMode` | `auto` 优先使用 Worker；`worker` 强制 Worker 传输；`main-thread` 用于调试或受限环境。 |
-| `wasmThreading` | `single-thread` 加载单线程 WASM；`pthread` 加载多线程版本。 |
-| `moduleUrl`, `wasmUrl` | 打包工具或部署改了资源路径时，重写单线程运行时的资源 URL。两个必须一起设。 |
-| `pthreadModuleUrl`, `pthreadWasmUrl` | 同上，用于多线程运行时。两个必须一起设。 |
+| `wasmThreading` | `pthread` 加载内置多线程运行时。`single-thread` 仅在显式提供自定义 `moduleUrl` 和 `wasmUrl` 资源时有效。 |
+| `moduleUrl`, `wasmUrl` | 重写当前选择的运行时资源 URL。两个必须一起设。 |
 | `browserCache` | 控制浏览器 GGUF 缓存的 OPFS 分片阈值和加载行为。 |
 | `trustedOrigins` | 允许跨域加载运行时资源。默认只允许同源。 |
 | `workerUrl` | 打包工具找不到 Worker 时手动指定入口 URL。 |
@@ -60,8 +59,8 @@ Python 和 Rust 通过各语言自己的描述符和配置类/结构体提供相
 
 | 模式 | 说明 |
 | --- | --- |
-| `single-thread`（默认） | 加载单线程 WASM 运行时。兼容性最好，不需要跨域隔离头。 |
-| `pthread` | 加载多线程 WASM 运行时。需要 `SharedArrayBuffer` 和 COOP/COEP 响应头。 |
+| `pthread`（默认） | 加载内置多线程 WASM 运行时。需要 `SharedArrayBuffer` 和 COOP/COEP 响应头。 |
+| `single-thread` | 仅用于显式提供自定义单线程 `moduleUrl` 和 `wasmUrl` 资源的场景。 |
 
 ### `browserCache`
 

--- a/lib/web/src/engine/runtime-assets.ts
+++ b/lib/web/src/engine/runtime-assets.ts
@@ -14,7 +14,20 @@ export interface RuntimeUrls {
 export type WasmThreadingPreference = 'single-thread' | 'pthread';
 export type WasmThreadingMode = 'single-thread' | 'pthread';
 export type RuntimeBackendOverride = 'cpu';
-type BundledRuntimeFlavor = 'webgpu-jspi' | 'cpu-nojspi';
+
+interface BundledRuntimeAsset {
+  readonly artifactName: string;
+  readonly backendOverride: RuntimeBackendOverride | null;
+}
+
+const DEFAULT_BUNDLED_RUNTIME: BundledRuntimeAsset = {
+  artifactName: 'sipp-wasm-pthread',
+  backendOverride: null,
+};
+const FIREFOX_BUNDLED_RUNTIME: BundledRuntimeAsset = {
+  artifactName: 'sipp-wasm-pthread-cpu-nojspi',
+  backendOverride: 'cpu',
+};
 
 function normalizeOptionalString(value: string | undefined): string | undefined {
   const trimmed = value?.trim();
@@ -70,8 +83,8 @@ function packageRootForOptimizedDependency(optimizedPath: string): string | null
 }
 
 export function getDefaultRuntimeUrls(importerUrl: string = import.meta.url): RuntimeUrls {
-  const threading = resolveRuntimeThreadingMode({});
-  return getDefaultRuntimeUrlsForThreading(threading, importerUrl);
+  assertWasmPthreadsSupported();
+  return bundledRuntimeUrls(importerUrl);
 }
 
 export function supportsWasmPthreads(): boolean {
@@ -85,7 +98,11 @@ export function supportsWasmPthreads(): boolean {
 export function resolveRuntimeThreadingMode(
   config: Pick<
     SippClientOptions,
-    'moduleUrl' | 'wasmUrl' | 'pthreadModuleUrl' | 'pthreadWasmUrl' | 'wasmThreading'
+    | 'moduleUrl'
+    | 'wasmUrl'
+    | 'pthreadModuleUrl'
+    | 'pthreadWasmUrl'
+    | 'wasmThreading'
   >
 ): WasmThreadingMode {
   const configuredSingleThread =
@@ -99,26 +116,31 @@ export function resolveRuntimeThreadingMode(
     return 'single-thread';
   }
 
-  switch (config.wasmThreading ?? 'single-thread') {
-    case 'single-thread':
-      return 'single-thread';
-    case 'pthread':
-      assertWasmPthreadsSupported();
-      return 'pthread';
+  if (config.wasmThreading === 'single-thread') {
+    throw new Error(
+      'The bundled Sipp browser runtime is pthread-only. Serve with COOP/COEP headers for SharedArrayBuffer support, or provide explicit moduleUrl and wasmUrl for a custom single-thread runtime.'
+    );
   }
+
+  assertWasmPthreadsSupported();
+  return 'pthread';
 }
 
 export function resolveRuntimeBackendOverride(
   config: Pick<
     SippClientOptions,
-    'moduleUrl' | 'wasmUrl' | 'pthreadModuleUrl' | 'pthreadWasmUrl' | 'wasmThreading'
+    | 'moduleUrl'
+    | 'wasmUrl'
+    | 'pthreadModuleUrl'
+    | 'pthreadWasmUrl'
+    | 'wasmThreading'
   >
 ): RuntimeBackendOverride | null {
   if (hasRuntimeUrlOverride(config)) {
     return null;
   }
-  const threading = resolveRuntimeThreadingMode(config);
-  return defaultBundledRuntimeFlavor(threading) === 'cpu-nojspi' ? 'cpu' : null;
+  resolveRuntimeThreadingMode(config);
+  return selectBundledRuntime().backendOverride;
 }
 
 function assertWasmPthreadsSupported(): void {
@@ -126,50 +148,33 @@ function assertWasmPthreadsSupported(): void {
     return;
   }
   throw new Error(
-    'The pthread wasm runtime requires SharedArrayBuffer and cross-origin isolation. Serve the app with COOP/COEP headers or use wasmThreading: "single-thread".'
+    'The bundled Sipp browser runtime requires SharedArrayBuffer and cross-origin isolation. Serve the app with COOP/COEP headers or provide explicit moduleUrl and wasmUrl for a custom single-thread runtime.'
   );
 }
 
-function getDefaultRuntimeUrlsForThreading(
-  threading: WasmThreadingMode,
-  importerUrl: string = import.meta.url
-): RuntimeUrls {
+function bundledRuntimeUrls(importerUrl: string = import.meta.url): RuntimeUrls {
+  const runtime = selectBundledRuntime();
   const optimizedRuntimeAssetsUrl = resolveOptimizedPackageAssetUrl(
     'dist/esm/engine/runtime-assets.js',
     importerUrl
   );
-  const baseArtifactPrefix = threading === 'pthread' ? 'sipp-wasm-pthread' : 'sipp-wasm';
-  const artifactPrefix = `${baseArtifactPrefix}${runtimeArtifactSuffix(
-    defaultBundledRuntimeFlavor(threading)
-  )}`;
-
-  const urls = optimizedRuntimeAssetsUrl == null
-    ? {
-      moduleUrl: new URL(`../../wasm/${artifactPrefix}.js`, import.meta.url).toString(),
-      wasmUrl: new URL(`../../wasm/${artifactPrefix}.wasm`, import.meta.url).toString(),
-    }
-    : {
-      moduleUrl: new URL(`../../wasm/${artifactPrefix}.js`, optimizedRuntimeAssetsUrl).toString(),
-      wasmUrl: new URL(`../../wasm/${artifactPrefix}.wasm`, optimizedRuntimeAssetsUrl).toString(),
-    };
+  const runtimeAssetsBaseUrl = optimizedRuntimeAssetsUrl ?? import.meta.url;
 
   return {
-    ...urls,
-    threading,
+    moduleUrl: new URL(
+      `../../wasm/${runtime.artifactName}.js`,
+      runtimeAssetsBaseUrl
+    ).toString(),
+    wasmUrl: new URL(
+      `../../wasm/${runtime.artifactName}.wasm`,
+      runtimeAssetsBaseUrl
+    ).toString(),
+    threading: 'pthread',
   };
 }
 
-function runtimeArtifactSuffix(runtimeFlavor: BundledRuntimeFlavor): string {
-  switch (runtimeFlavor) {
-    case 'webgpu-jspi':
-      return '';
-    case 'cpu-nojspi':
-      return '-cpu-nojspi';
-  }
-}
-
-function defaultBundledRuntimeFlavor(threading: WasmThreadingMode): BundledRuntimeFlavor {
-  return threading === 'pthread' && isFirefoxLikeRuntime() ? 'cpu-nojspi' : 'webgpu-jspi';
+function selectBundledRuntime(): BundledRuntimeAsset {
+  return isFirefoxLikeRuntime() ? FIREFOX_BUNDLED_RUNTIME : DEFAULT_BUNDLED_RUNTIME;
 }
 
 function isFirefoxLikeRuntime(): boolean {
@@ -235,37 +240,29 @@ export function resolveRuntimeUrls(
   }
 
   const threading = resolveRuntimeThreadingMode(config);
-  const resolved =
-    threading === 'pthread'
-      ? configuredPthreadModuleUrl == null
-        ? configuredModuleUrl != null && config.wasmThreading === 'pthread'
-          ? {
-            moduleUrl: parseConfiguredUrl(configuredModuleUrl, 'moduleUrl'),
-            wasmUrl: parseConfiguredUrl(configuredWasmUrl!, 'wasmUrl'),
-          }
-          : (() => {
-            const defaults = getDefaultRuntimeUrlsForThreading('pthread');
-            return {
-              moduleUrl: new URL(defaults.moduleUrl),
-              wasmUrl: new URL(defaults.wasmUrl),
-            };
-          })()
-        : {
-          moduleUrl: parseConfiguredUrl(configuredPthreadModuleUrl, 'pthreadModuleUrl'),
-          wasmUrl: parseConfiguredUrl(configuredPthreadWasmUrl!, 'pthreadWasmUrl'),
-        }
-      : configuredModuleUrl == null
-        ? (() => {
-          const defaults = getDefaultRuntimeUrlsForThreading('single-thread');
-          return {
-            moduleUrl: new URL(defaults.moduleUrl),
-            wasmUrl: new URL(defaults.wasmUrl),
-          };
-        })()
-        : {
-          moduleUrl: parseConfiguredUrl(configuredModuleUrl, 'moduleUrl'),
-          wasmUrl: parseConfiguredUrl(configuredWasmUrl!, 'wasmUrl'),
-        };
+  let resolved: { moduleUrl: URL; wasmUrl: URL };
+  if (threading === 'single-thread') {
+    resolved = {
+      moduleUrl: parseConfiguredUrl(configuredModuleUrl!, 'moduleUrl'),
+      wasmUrl: parseConfiguredUrl(configuredWasmUrl!, 'wasmUrl'),
+    };
+  } else if (configuredPthreadModuleUrl != null) {
+    resolved = {
+      moduleUrl: parseConfiguredUrl(configuredPthreadModuleUrl, 'pthreadModuleUrl'),
+      wasmUrl: parseConfiguredUrl(configuredPthreadWasmUrl!, 'pthreadWasmUrl'),
+    };
+  } else if (configuredModuleUrl != null && config.wasmThreading === 'pthread') {
+    resolved = {
+      moduleUrl: parseConfiguredUrl(configuredModuleUrl, 'moduleUrl'),
+      wasmUrl: parseConfiguredUrl(configuredWasmUrl!, 'wasmUrl'),
+    };
+  } else {
+    const defaults = bundledRuntimeUrls();
+    resolved = {
+      moduleUrl: new URL(defaults.moduleUrl),
+      wasmUrl: new URL(defaults.wasmUrl),
+    };
+  }
 
   const trustedOrigins = resolveTrustedOrigins(config.trustedOrigins);
   if (trustedOrigins.size > 0) {

--- a/lib/web/src/engine/runtime-assets.ts
+++ b/lib/web/src/engine/runtime-assets.ts
@@ -98,27 +98,20 @@ export function supportsWasmPthreads(): boolean {
 export function resolveRuntimeThreadingMode(
   config: Pick<
     SippClientOptions,
-    | 'moduleUrl'
-    | 'wasmUrl'
-    | 'pthreadModuleUrl'
-    | 'pthreadWasmUrl'
-    | 'wasmThreading'
+    'moduleUrl' | 'wasmUrl' | 'wasmThreading'
   >
 ): WasmThreadingMode {
-  const configuredSingleThread =
+  const hasSelectedRuntimeOverride =
     normalizeOptionalString(config.moduleUrl) != null ||
     normalizeOptionalString(config.wasmUrl) != null;
-  const configuredPthread =
-    normalizeOptionalString(config.pthreadModuleUrl) != null ||
-    normalizeOptionalString(config.pthreadWasmUrl) != null;
 
-  if (configuredSingleThread && !configuredPthread && config.wasmThreading !== 'pthread') {
+  if (config.wasmThreading === 'single-thread' && hasSelectedRuntimeOverride) {
     return 'single-thread';
   }
 
   if (config.wasmThreading === 'single-thread') {
     throw new Error(
-      'The bundled Sipp browser runtime is pthread-only. Serve with COOP/COEP headers for SharedArrayBuffer support, or provide explicit moduleUrl and wasmUrl for a custom single-thread runtime.'
+      'The bundled Sipp browser runtime is pthread-only. Provide moduleUrl and wasmUrl for a custom single-thread runtime.'
     );
   }
 
@@ -148,7 +141,7 @@ function assertWasmPthreadsSupported(): void {
     return;
   }
   throw new Error(
-    'The bundled Sipp browser runtime requires SharedArrayBuffer and cross-origin isolation. Serve the app with COOP/COEP headers or provide explicit moduleUrl and wasmUrl for a custom single-thread runtime.'
+    'The bundled Sipp browser runtime requires SharedArrayBuffer and cross-origin isolation. Serve the app with COOP/COEP headers, or set wasmThreading: "single-thread" with moduleUrl and wasmUrl for a custom single-thread runtime.'
   );
 }
 
@@ -246,15 +239,15 @@ export function resolveRuntimeUrls(
       moduleUrl: parseConfiguredUrl(configuredModuleUrl!, 'moduleUrl'),
       wasmUrl: parseConfiguredUrl(configuredWasmUrl!, 'wasmUrl'),
     };
+  } else if (configuredModuleUrl != null) {
+    resolved = {
+      moduleUrl: parseConfiguredUrl(configuredModuleUrl, 'moduleUrl'),
+      wasmUrl: parseConfiguredUrl(configuredWasmUrl!, 'wasmUrl'),
+    };
   } else if (configuredPthreadModuleUrl != null) {
     resolved = {
       moduleUrl: parseConfiguredUrl(configuredPthreadModuleUrl, 'pthreadModuleUrl'),
       wasmUrl: parseConfiguredUrl(configuredPthreadWasmUrl!, 'pthreadWasmUrl'),
-    };
-  } else if (configuredModuleUrl != null && config.wasmThreading === 'pthread') {
-    resolved = {
-      moduleUrl: parseConfiguredUrl(configuredModuleUrl, 'moduleUrl'),
-      wasmUrl: parseConfiguredUrl(configuredWasmUrl!, 'wasmUrl'),
     };
   } else {
     const defaults = bundledRuntimeUrls();

--- a/lib/web/src/worker/model-service-client.ts
+++ b/lib/web/src/worker/model-service-client.ts
@@ -2,9 +2,8 @@ import type { SippClientOptions } from '../engine/browser-client.js';
 import {
   resolveOptimizedPackageAssetUrl,
   resolveRuntimeBackendOverride,
+  resolveRuntimeThreadingMode,
   resolveRuntimeUrls,
-  supportsWasmPthreads,
-  type WasmThreadingMode,
 } from '../engine/runtime-assets.js';
 import { ObservabilityController } from '../models/observability-controller.js';
 import { observabilitySnapshotToEngineState } from '../models/observability-controller.js';
@@ -93,10 +92,7 @@ function toWorkerRuntimeConfig(config: SippClientOptions): WorkerRuntimeConfig {
     !hasRuntimeUrlOverride
       ? null
       : resolveRuntimeUrls(config);
-  const wasmThreading =
-    runtimeUrls?.threading ??
-    config.wasmThreading ??
-    defaultWorkerThreadingMode();
+  const wasmThreading = runtimeUrls?.threading ?? resolveRuntimeThreadingMode(config);
   const defaultBackendOverride = resolveRuntimeBackendOverride({
     ...config,
     wasmThreading,
@@ -112,10 +108,6 @@ function toWorkerRuntimeConfig(config: SippClientOptions): WorkerRuntimeConfig {
     browserCache: config.browserCache,
     trustedOrigins: config.trustedOrigins,
   };
-}
-
-function defaultWorkerThreadingMode(): WasmThreadingMode {
-  return supportsWasmPthreads() ? 'pthread' : 'single-thread';
 }
 
 function toWorkerQueryOptions(

--- a/lib/web/src/worker/model-service-entry.ts
+++ b/lib/web/src/worker/model-service-entry.ts
@@ -141,7 +141,7 @@ function tokenEmissionOptionsFor(
   if (!postTokenRingReady()) {
     throw new QueryError(
       'STREAMING_UNAVAILABLE',
-      'Pthread worker token streaming requires shared wasm memory. Serve the page with cross-origin isolation or use wasmThreading: "single-thread".'
+      'Pthread worker token streaming requires shared wasm memory. Serve the page with cross-origin isolation.'
     );
   }
   return {

--- a/lib/web/tests/engine/runtime-assets.test.ts
+++ b/lib/web/tests/engine/runtime-assets.test.ts
@@ -46,30 +46,36 @@ function withLocation<T>(href: string | undefined, callback: () => T): T {
 }
 
 test('resolveRuntimeUrls uses bundled runtime assets when no overrides are provided', () => {
-  const resolved = withLocation(undefined, () => resolveRuntimeUrls({}));
-  assert.deepEqual(resolved, getDefaultRuntimeUrls());
+  withWasmPthreadSupport(() => {
+    const resolved = withLocation(undefined, () => resolveRuntimeUrls({}));
+    assert.deepEqual(resolved, getDefaultRuntimeUrls());
+  });
 });
 
 test('getDefaultRuntimeUrls maps Vite optimized deps back to package wasm assets', () => {
-  assert.deepEqual(
-    getDefaultRuntimeUrls('https://app.test/node_modules/.vite/deps/@noumena-labs_sipp.js?v=123'),
-    {
-      moduleUrl: 'https://app.test/node_modules/@noumena-labs/sipp/dist/wasm/sipp-wasm.js',
-      wasmUrl: 'https://app.test/node_modules/@noumena-labs/sipp/dist/wasm/sipp-wasm.wasm',
-      threading: 'single-thread',
-    }
-  );
+  withWasmPthreadSupport(() => {
+    assert.deepEqual(
+      getDefaultRuntimeUrls('https://app.test/node_modules/.vite/deps/@noumena-labs_sipp.js?v=123'),
+      {
+        moduleUrl: 'https://app.test/node_modules/@noumena-labs/sipp/dist/wasm/sipp-wasm-pthread.js',
+        wasmUrl: 'https://app.test/node_modules/@noumena-labs/sipp/dist/wasm/sipp-wasm-pthread.wasm',
+        threading: 'pthread',
+      }
+    );
+  });
 });
 
 test('getDefaultRuntimeUrls maps public Vite optimized deps back to package wasm assets', () => {
-  assert.deepEqual(
-    getDefaultRuntimeUrls('https://app.test/node_modules/.vite/deps/@sipphq_sipp.js?v=123'),
-    {
-      moduleUrl: 'https://app.test/node_modules/@sipphq/sipp/dist/wasm/sipp-wasm.js',
-      wasmUrl: 'https://app.test/node_modules/@sipphq/sipp/dist/wasm/sipp-wasm.wasm',
-      threading: 'single-thread',
-    }
-  );
+  withWasmPthreadSupport(() => {
+    assert.deepEqual(
+      getDefaultRuntimeUrls('https://app.test/node_modules/.vite/deps/@sipphq_sipp.js?v=123'),
+      {
+        moduleUrl: 'https://app.test/node_modules/@sipphq/sipp/dist/wasm/sipp-wasm-pthread.js',
+        wasmUrl: 'https://app.test/node_modules/@sipphq/sipp/dist/wasm/sipp-wasm-pthread.wasm',
+        threading: 'pthread',
+      }
+    );
+  });
 });
 
 test('resolveOptimizedPackageAssetUrl returns null for normal module URLs', () => {
@@ -102,15 +108,22 @@ test('resolveOptimizedPackageAssetUrl preserves a Vite dev base path', () => {
   );
 });
 
-test('resolveRuntimeUrls defaults to the single-thread artifact when wasm pthreads are available', () => {
+test('resolveRuntimeUrls defaults to the pthread artifact when wasm pthreads are available', () => {
   withWasmPthreadSupport(() => {
     assert.equal(supportsWasmPthreads(), true);
-    assert.equal(resolveRuntimeThreadingMode({}), 'single-thread');
+    assert.equal(resolveRuntimeThreadingMode({}), 'pthread');
     const resolved = resolveRuntimeUrls({});
-    assert.match(resolved.moduleUrl, /sipp-wasm\.js$/);
-    assert.match(resolved.wasmUrl, /sipp-wasm\.wasm$/);
-    assert.equal(resolved.threading, 'single-thread');
+    assert.match(resolved.moduleUrl, /sipp-wasm-pthread\.js$/);
+    assert.match(resolved.wasmUrl, /sipp-wasm-pthread\.wasm$/);
+    assert.equal(resolved.threading, 'pthread');
   });
+});
+
+test('resolveRuntimeUrls rejects bundled runtimes without wasm pthread support', () => {
+  assert.throws(
+    () => resolveRuntimeUrls({}),
+    /requires SharedArrayBuffer and cross-origin isolation/
+  );
 });
 
 test('resolveRuntimeUrls selects the pthread artifact when explicitly requested', () => {
@@ -123,11 +136,11 @@ test('resolveRuntimeUrls selects the pthread artifact when explicitly requested'
   });
 });
 
-test('resolveRuntimeUrls auto-selects CPU non-JSPI on Firefox pthread runtime', () => {
-  withNavigatorUserAgent('Mozilla/5.0 Firefox/152.0.2', () => {
+test('resolveRuntimeUrls auto-selects CPU non-JSPI on Firefox', () => {
+  withNavigatorUserAgent('Mozilla/5.0 Firefox/127.0', () => {
     withWasmPthreadSupport(() => {
-      assert.equal(resolveRuntimeThreadingMode({ wasmThreading: 'pthread' }), 'pthread');
-      const resolved = resolveRuntimeUrls({ wasmThreading: 'pthread' });
+      assert.equal(resolveRuntimeThreadingMode({}), 'pthread');
+      const resolved = resolveRuntimeUrls({});
       assert.match(resolved.moduleUrl, /sipp-wasm-pthread-cpu-nojspi\.js$/);
       assert.match(resolved.wasmUrl, /sipp-wasm-pthread-cpu-nojspi\.wasm$/);
       assert.equal(resolved.threading, 'pthread');
@@ -158,12 +171,12 @@ test('resolveRuntimeBackendOverride does not force CPU for custom runtime URLs',
   });
 });
 
-test('resolveRuntimeUrls honors the single-thread runtime preference', () => {
+test('resolveRuntimeUrls rejects bundled single-thread runtime preference', () => {
   withWasmPthreadSupport(() => {
-    const resolved = resolveRuntimeUrls({ wasmThreading: 'single-thread' });
-    assert.match(resolved.moduleUrl, /sipp-wasm\.js$/);
-    assert.match(resolved.wasmUrl, /sipp-wasm\.wasm$/);
-    assert.equal(resolved.threading, 'single-thread');
+    assert.throws(
+      () => resolveRuntimeUrls({ wasmThreading: 'single-thread' }),
+      /bundled Sipp browser runtime is pthread-only/
+    );
   });
 });
 

--- a/lib/web/tests/engine/runtime-assets.test.ts
+++ b/lib/web/tests/engine/runtime-assets.test.ts
@@ -162,8 +162,8 @@ test('resolveRuntimeBackendOverride does not force CPU for custom runtime URLs',
       assert.equal(
         resolveRuntimeBackendOverride({
           wasmThreading: 'pthread',
-          pthreadModuleUrl: '/custom.js',
-          pthreadWasmUrl: '/custom.wasm',
+          moduleUrl: '/custom.js',
+          wasmUrl: '/custom.wasm',
         }),
         null
       );
@@ -181,8 +181,43 @@ test('resolveRuntimeUrls rejects bundled single-thread runtime preference', () =
 });
 
 test('resolveRuntimeUrls uses the current window-like location for relative overrides', () => {
+  withWasmPthreadSupport(() => {
+    const resolved = withLocation('https://app.test/ui/index.html', () =>
+      resolveRuntimeUrls({
+        moduleUrl: './assets/runtime.js',
+        wasmUrl: './assets/runtime.wasm',
+      })
+    );
+
+    assert.deepEqual(resolved, {
+      moduleUrl: 'https://app.test/ui/assets/runtime.js',
+      wasmUrl: 'https://app.test/ui/assets/runtime.wasm',
+      threading: 'pthread',
+    });
+  });
+});
+
+test('resolveRuntimeUrls uses the current worker-like location for relative overrides', () => {
+  withWasmPthreadSupport(() => {
+    const resolved = withLocation('https://app.test/pkg/worker/model-service-entry.js', () =>
+      resolveRuntimeUrls({
+        moduleUrl: '../wasm/custom-runtime.js',
+        wasmUrl: '../wasm/custom-runtime.wasm',
+      })
+    );
+
+    assert.deepEqual(resolved, {
+      moduleUrl: 'https://app.test/pkg/wasm/custom-runtime.js',
+      wasmUrl: 'https://app.test/pkg/wasm/custom-runtime.wasm',
+      threading: 'pthread',
+    });
+  });
+});
+
+test('resolveRuntimeUrls uses moduleUrl and wasmUrl for custom single-thread runtime when selected', () => {
   const resolved = withLocation('https://app.test/ui/index.html', () =>
     resolveRuntimeUrls({
+      wasmThreading: 'single-thread',
       moduleUrl: './assets/runtime.js',
       wasmUrl: './assets/runtime.wasm',
     })
@@ -195,18 +230,20 @@ test('resolveRuntimeUrls uses the current window-like location for relative over
   });
 });
 
-test('resolveRuntimeUrls uses the current worker-like location for relative overrides', () => {
-  const resolved = withLocation('https://app.test/pkg/worker/model-service-entry.js', () =>
-    resolveRuntimeUrls({
-      moduleUrl: '../wasm/custom-runtime.js',
-      wasmUrl: '../wasm/custom-runtime.wasm',
-    })
-  );
+test('resolveRuntimeUrls accepts legacy pthread runtime aliases', () => {
+  withWasmPthreadSupport(() => {
+    const resolved = withLocation('https://app.test/ui/index.html', () =>
+      resolveRuntimeUrls({
+        pthreadModuleUrl: './assets/runtime.js',
+        pthreadWasmUrl: './assets/runtime.wasm',
+      })
+    );
 
-  assert.deepEqual(resolved, {
-    moduleUrl: 'https://app.test/pkg/wasm/custom-runtime.js',
-    wasmUrl: 'https://app.test/pkg/wasm/custom-runtime.wasm',
-    threading: 'single-thread',
+    assert.deepEqual(resolved, {
+      moduleUrl: 'https://app.test/ui/assets/runtime.js',
+      wasmUrl: 'https://app.test/ui/assets/runtime.wasm',
+      threading: 'pthread',
+    });
   });
 });
 
@@ -215,6 +252,7 @@ test('resolveRuntimeUrls blocks cross-origin overrides when trustedOrigins are n
     assert.throws(
       () =>
         resolveRuntimeUrls({
+          wasmThreading: 'single-thread',
           moduleUrl: 'https://cdn.test/runtime.js',
           wasmUrl: 'https://cdn.test/runtime.wasm',
         }),

--- a/lib/web/tests/runtime/main-thread/engine-runtime.test.ts
+++ b/lib/web/tests/runtime/main-thread/engine-runtime.test.ts
@@ -91,6 +91,7 @@ test('MainThreadEngineRuntime points pthread workers at the selected runtime mod
 test('MainThreadEngineRuntime rejects stale browser runtime ABI artifacts', async () => {
   const runtime = new MainThreadEngineRuntime({
     executionMode: 'main-thread',
+    wasmThreading: 'single-thread',
     moduleUrl: 'https://example.test/runtime.js',
     wasmUrl: 'https://example.test/runtime.wasm',
   });

--- a/xtask/src/cli.rs
+++ b/xtask/src/cli.rs
@@ -728,7 +728,7 @@ pub struct TestUnitBackendArgs {
 #[derive(Args)]
 pub struct TestUnitWasmArgs {
     /// WASM runtime variant to build before running browser tests.
-    #[arg(long = "wasm-threading", value_enum, default_value = "all")]
+    #[arg(long = "wasm-threading", value_enum, default_value = "pthread")]
     pub wasm_threading: WasmThreading,
 }
 
@@ -1820,7 +1820,7 @@ pub struct BackendArgs {
 #[derive(Args)]
 pub struct WasmBuildArgs {
     /// WASM runtime variant to build.
-    #[arg(long, value_enum, default_value = "all")]
+    #[arg(long, value_enum, default_value = "pthread")]
     pub threading: WasmThreading,
     /// Browser runtime backend/async flavor to build.
     #[arg(long, value_enum, default_value = "auto")]

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -154,7 +154,7 @@ fn run_build(target: BuildCommands, sh: &Shell, ctx: &BuildContext) -> Result<()
     match target {
         BuildCommands::All => {
             targets::core::build(sh, ctx)?;
-            targets::wasm::build(sh, ctx, WasmThreading::All, WasmRuntime::Auto)?;
+            targets::wasm::build(sh, ctx, WasmThreading::Pthread, WasmRuntime::Auto)?;
             targets::python::build(sh, ctx, None)?;
             targets::node::build(sh, ctx, None)?;
             targets::cli::build(sh, ctx, None)?;

--- a/xtask/src/run.rs
+++ b/xtask/src/run.rs
@@ -171,7 +171,7 @@ fn prepend_path(path: &str, current: &str) -> String {
 fn build_one_demo(sh: &Shell, ctx: &BuildContext, demo: DemoName) -> Result<()> {
     output::phase(&format!("Build browser demo: {}", demo.slug()));
     ensure_javascript_workspace_dependencies(sh, ctx, &ctx.demo_dir(demo.slug()))?;
-    targets::wasm::build(sh, ctx, WasmThreading::All, WasmRuntime::Auto)?;
+    targets::wasm::build(sh, ctx, WasmThreading::Pthread, WasmRuntime::Auto)?;
     build_demo_only(sh, ctx, demo)
 }
 
@@ -196,7 +196,7 @@ fn serve_demo(sh: &Shell, ctx: &BuildContext, args: &RunDemoServeArgs) -> Result
 
     if !args.no_build {
         ensure_javascript_workspace_dependencies(sh, ctx, &ctx.demo_dir(args.demo.slug()))?;
-        targets::wasm::build(sh, ctx, WasmThreading::All, WasmRuntime::Auto)?;
+        targets::wasm::build(sh, ctx, WasmThreading::Pthread, WasmRuntime::Auto)?;
         if matches!(args.mode, DemoServeMode::Preview) {
             build_demo_only(sh, ctx, args.demo)?;
         }
@@ -232,7 +232,7 @@ fn serve_demo(sh: &Shell, ctx: &BuildContext, args: &RunDemoServeArgs) -> Result
 fn build_one_tool(sh: &Shell, ctx: &BuildContext, tool: ToolName) -> Result<()> {
     output::phase(&format!("Build tool: {}", tool.slug()));
     ensure_javascript_workspace_dependencies(sh, ctx, &tool_dir(ctx, tool))?;
-    targets::wasm::build(sh, ctx, WasmThreading::All, WasmRuntime::Auto)?;
+    targets::wasm::build(sh, ctx, WasmThreading::Pthread, WasmRuntime::Auto)?;
     build_tool_only(sh, ctx, tool)
 }
 
@@ -257,7 +257,7 @@ fn serve_tool(sh: &Shell, ctx: &BuildContext, args: &RunToolServeArgs) -> Result
 
     if !args.no_build {
         ensure_javascript_workspace_dependencies(sh, ctx, &tool_dir(ctx, args.tool))?;
-        targets::wasm::build(sh, ctx, WasmThreading::All, WasmRuntime::Auto)?;
+        targets::wasm::build(sh, ctx, WasmThreading::Pthread, WasmRuntime::Auto)?;
         if matches!(args.mode, DemoServeMode::Preview) {
             build_tool_only(sh, ctx, args.tool)?;
         }
@@ -300,7 +300,7 @@ fn serve_browser_example(
 
     if !args.no_build {
         ensure_javascript_workspace_dependencies(sh, ctx, &example_dir(ctx, example))?;
-        targets::wasm::build(sh, ctx, WasmThreading::All, WasmRuntime::Auto)?;
+        targets::wasm::build(sh, ctx, WasmThreading::Pthread, WasmRuntime::Auto)?;
         if matches!(args.mode, DemoServeMode::Preview) {
             build_example_only(sh, ctx, example)?;
         }
@@ -517,7 +517,7 @@ fn run_web_gateway_example(
     let example = ExampleName::Browser;
     if !args.no_build {
         ensure_javascript_workspace_dependencies(sh, ctx, &example_dir(ctx, example))?;
-        targets::wasm::build(sh, ctx, WasmThreading::All, WasmRuntime::Auto)?;
+        targets::wasm::build(sh, ctx, WasmThreading::Pthread, WasmRuntime::Auto)?;
         if matches!(args.mode, DemoServeMode::Preview) {
             build_example_only(sh, ctx, example)?;
         }

--- a/xtask/src/test.rs
+++ b/xtask/src/test.rs
@@ -415,7 +415,7 @@ fn run_smoke(sh: &Shell, ctx: &BuildContext, args: &TestSmokeArgs) -> Result<()>
     };
     let options = SuiteRunOptions {
         backend: selection.backend,
-        wasm_threading: WasmThreading::All,
+        wasm_threading: WasmThreading::Pthread,
         coverage: false,
         model: selection.model.as_deref(),
         offline: selection.offline,
@@ -1170,7 +1170,7 @@ fn run_browser_example_smoke(
     output::path("Model", &model);
     let example_dir = ctx.browser_example_dir();
     ensure_javascript_workspace_dependencies(sh, ctx, &[example_dir.clone()])?;
-    targets::wasm::build(sh, ctx, WasmThreading::All, WasmRuntime::Auto)?;
+    targets::wasm::build(sh, ctx, WasmThreading::Pthread, WasmRuntime::Auto)?;
     ensure_playwright_chromium(sh, ctx)?;
 
     output::path("Example workspace", &example_dir);
@@ -1208,7 +1208,7 @@ fn run_playground_browser_runtime_smoke(
     output::phase("Playground browser runtime smoke");
     let playground_dir = ctx.playground_dir();
     ensure_javascript_workspace_dependencies(sh, ctx, &[playground_dir.clone()])?;
-    targets::wasm::build(sh, ctx, WasmThreading::All, WasmRuntime::Auto)?;
+    targets::wasm::build(sh, ctx, WasmThreading::Pthread, WasmRuntime::Auto)?;
     ensure_playwright_chromium(sh, ctx)?;
 
     output::path("Playground workspace", &playground_dir);
@@ -4232,7 +4232,7 @@ impl Default for UnitSelection {
             suites: Vec::new(),
             package: None,
             backend: Backend::Cpu,
-            wasm_threading: WasmThreading::All,
+            wasm_threading: WasmThreading::Pthread,
             filters: json!({}),
         }
     }

--- a/xtask/src/tests/cli_tests.rs
+++ b/xtask/src/tests/cli_tests.rs
@@ -44,7 +44,7 @@ fn build_commands_parse_backend_defaults_and_overrides() {
     };
     assert_eq!(args.backend, Some(Backend::Vulkan));
 
-    let cli = Cli::parse_from(["xtask", "build", "wasm", "--threading", "pthread"]);
+    let cli = Cli::parse_from(["xtask", "build", "wasm"]);
     let Commands::Build { target } = cli.command else {
         panic!("expected build command");
     };
@@ -481,6 +481,21 @@ fn test_unit_and_smoke_targets_parse() {
         panic!("expected rust unit target");
     };
     assert_eq!(args.package.as_deref(), Some("sipp-sys"));
+
+    let cli = Cli::parse_from(["xtask", "test", "unit", "suite", "browser"]);
+    let Commands::Test { command } = cli.command else {
+        panic!("expected test command");
+    };
+    let TestCommands::Unit(args) = command else {
+        panic!("expected unit command");
+    };
+    let TestUnitCommands::Suite(args) = args.command else {
+        panic!("expected unit suite command");
+    };
+    let TestUnitSuiteTarget::Browser(args) = args.target else {
+        panic!("expected browser package unit target");
+    };
+    assert_eq!(args.wasm_threading, WasmThreading::Pthread);
 
     let cli = Cli::parse_from([
         "xtask",


### PR DESCRIPTION
In this PR, it handles the wasm runtime across different browsers. By default, the packaged browser runtime is pthread-based and requires SharedArrayBuffer plus COOP/COEP headers. The runtime will automatically select CPU no-JSPI for Firefox. It now requires wasmThreading: 'single-thread' only when providing custom single-thread assets and removes docs wording around pthread-specific asset override aliases and fallback behavior.