### PR TITLE
Update demos for Firefox 

### DIFF
--- a/demos/avatar/src/App.tsx
+++ b/demos/avatar/src/App.tsx
@@ -9,7 +9,7 @@
 //////////////////////////////////////////////////////////////////////////////
 
 import { useEffect, useMemo, useRef, useState } from 'react';
-import { SippClient } from '@noumena-labs/sipp';
+import { SippClient, type ModelLoadProgress, type NativeRuntimeConfig } from '@noumena-labs/sipp';
 import {
   CharacterEventBus,
   createCharacterFromConfigUrl,
@@ -33,6 +33,29 @@ import type { ChatMessage } from './components/chat-types';
 const DEFAULT_CHARACTER_URL = '/characters/aria/character.json';
 const DEFAULT_MODEL_URL =
   'https://huggingface.co/LiquidAI/LFM2.5-1.2B-Instruct-GGUF/resolve/main/LFM2.5-1.2B-Instruct-Q4_K_M.gguf';
+const AVATAR_RUNTIME: NativeRuntimeConfig = {
+  placement: {
+    gpu_layers: 'all',
+  },
+  context: {
+    n_ctx: 4096,
+    n_parallel: 1,
+    n_threads: 2,
+    n_threads_batch: 4,
+  },
+  cache: {
+    mode: 'live_slot_and_snapshot',
+    retained_prefix_tokens: 256,
+    snapshot_interval_tokens: 32,
+  },
+  sampling: {
+    temperature: 0.6,
+    top_p: 0.9,
+    top_k: 40,
+    min_p: 0.05,
+    repeat_penalty: 1.05,
+  },
+};
 
 const SUGGESTED_PROMPTS = [
   'Who are you, Aria?',
@@ -149,22 +172,14 @@ export default function App() {
         kind: 'local',
         source: args.modelUrl,
         options: {
-          onProgress: (progress: { phase: string; percent: any; }) => {
+          onProgress: (progress: ModelLoadProgress) => {
             if (progress.phase === 'download') {
               setStatus(`Downloading model... ${Math.floor(progress.percent ?? 0)}%`);
             } else if (progress.phase === 'load') {
               setStatus('Loading into memory...');
             }
           },
-          runtime: {
-            sampling: {
-              temperature: 0.6,
-              top_p: 0.9,
-              top_k: 40,
-              min_p: 0.05,
-              repeat_penalty: 1.05,
-            },
-          },
+          runtime: AVATAR_RUNTIME,
         },
       });
 

--- a/demos/simulation/src/App.tsx
+++ b/demos/simulation/src/App.tsx
@@ -13,7 +13,7 @@
 //////////////////////////////////////////////////////////////////////////////
 
 import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from 'react';
-import { SippClient } from '@noumena-labs/sipp';
+import { SippClient, type ModelLoadProgress, type NativeRuntimeConfig } from '@noumena-labs/sipp';
 import { createCharacterFromConfigUrl } from '@noumena-labs/sipp/character';
 import { createDirectorFromConfigUrl } from '@noumena-labs/sipp/director';
 import { BrainActivityHud } from './components/BrainActivityHud';
@@ -95,6 +95,33 @@ const BRAIN_DEFINITIONS: readonly BrainDefinition[] = [
 ];
 
 const DEFAULT_MODEL_URL = 'https://huggingface.co/LiquidAI/LFM2.5-350M-GGUF/resolve/main/LFM2.5-350M-Q8_0.gguf';
+const SIMULATION_RUNTIME: NativeRuntimeConfig = {
+  placement: {
+    gpu_layers: 'all',
+  },
+  context: {
+    n_ctx: 4096,
+    n_parallel: 1,
+  },
+  cache: {
+    mode: 'live_slot_and_snapshot',
+    retained_prefix_tokens: 256,
+    snapshot_interval_tokens: 64,
+    max_snapshot_entries: 64,
+  },
+  scheduler: {
+    policy: {
+      mode: 'latency_first',
+    },
+  },
+  sampling: {
+    temperature: 0.5,
+    top_p: 0.9,
+    top_k: 40,
+    min_p: 0.05,
+    repeat_penalty: 1.05,
+  },
+};
 const SIMULATION_STEP_SECONDS = 0.15;
 const SIMULATION_STEP_DELAY_MS = SIMULATION_STEP_SECONDS * 1000;
 const DEFAULT_SCENARIO_SETTINGS: StartScenarioSettings = {
@@ -576,32 +603,15 @@ export default function App() {
           kind: 'local',
           source: url,
           options: {
-            onProgress: (progress: any) => {
+            onProgress: (progress: ModelLoadProgress) => {
               if (progress.phase === 'download') {
                 setStatus(`Downloading model ${Math.floor(progress.percent ?? 0)}%`);
               } else if (progress.phase === 'load') {
                 setStatus('Loading into memory');
               }
             },
-            observability: 'profile',
-            runtime: {
-              cache: {
-                snapshot_interval_tokens: 64,
-                max_snapshot_entries: 64,
-              },
-              scheduler: {
-                policy: {
-                  mode: 'latency_first' as const,
-                },
-              },
-              sampling: {
-                temperature: 0.5,
-                top_p: 0.9,
-                top_k: 40,
-                min_p: 0.05,
-                repeat_penalty: 1.05,
-              },
-            },
+            observability: 'runtime',
+            runtime: SIMULATION_RUNTIME,
           },
         });
 

--- a/demos/simulation/src/scenarios/courtyard-snack.ts
+++ b/demos/simulation/src/scenarios/courtyard-snack.ts
@@ -65,6 +65,9 @@ const MIN_FREE_COMPONENT_SIZE = 120;
 const GENERATION_ATTEMPTS = 40;
 const OBSTACLE_GROUP_COUNT_RANGE = { min: 3, max: 6 } as const;
 const GROUP_LENGTH_RANGE = { min: 2, max: 5 } as const;
+const REFEREE_TIMEOUT_MS = 90_000;
+const AGENT_QUERY_TIMEOUT_MS = 90_000;
+const NARRATION_TIMEOUT_MS = 120_000;
 const DEFAULT_COUNT_OPTIONS = {
   obstacles: { enabled: true, target: 12 },
   bats: { enabled: true, target: 1 },
@@ -154,9 +157,9 @@ export function createCourtyardScenario(options: CourtyardScenarioOptions = {}):
     directorCadenceTicks: 12,
     resolveRefereeTask: 'resolve_referee_event',
     narrateTask: 'narrate_scene',
-    refereeTimeoutMs: 30000,
-    agentQueryTimeoutMs: 30000,
-    narrationTimeoutMs: 15000,
+    refereeTimeoutMs: REFEREE_TIMEOUT_MS,
+    agentQueryTimeoutMs: AGENT_QUERY_TIMEOUT_MS,
+    narrationTimeoutMs: NARRATION_TIMEOUT_MS,
     maxMoveTicksBeforeReevaluation: 15,
   };
 }


### PR DESCRIPTION
This PR handles an edge case in the demos. 

## problems 
In both demos, when n_ctx is missing, Sipp passes no --ctx-size, and llama.cpp uses n_ctx = 0, meaning “use the model’s trained context length.” So the browser runtime may allocate/cache as if it needs a huge context window, even though the demo only needs a few thousand tokens.

In Chrome, this seems fine with WebGPU and enough budget, but in Firefox, as we used the CPU, the budget and headroom was limited, and we had to use the cap. 