### PR TITLE
Update the xtask setup

### DIFF
--- a/setup.cmd
+++ b/setup.cmd
@@ -11,9 +11,8 @@ set "SETUP_EXIT=%ERRORLEVEL%"
 endlocal & set "SETUP_EXIT=%SETUP_EXIT%" & set "SIPP_BIN=%ROOT%\.build\bin"
 
 if "%SETUP_EXIT%"=="0" (
-  if exist "%SIPP_BIN%\sipp.cmd" (
-    echo ;%PATH%; | find /I ";%SIPP_BIN%;" >nul
-    if errorlevel 1 set "PATH=%SIPP_BIN%;%PATH%"
+  if exist "%SIPP_BIN%\sipp-env.cmd" (
+    call "%SIPP_BIN%\sipp-env.cmd"
     echo.
     echo sipp is active in this CMD session.
   )

--- a/xtask/src/cli.rs
+++ b/xtask/src/cli.rs
@@ -337,6 +337,8 @@ Inspect, bootstrap, or configure developer toolchains.
 
 Examples:
   cargo xtask toolchain status
+  cargo xtask toolchain install bun
+  cargo xtask toolchain install cmake
   cargo xtask toolchain install uv
   cargo xtask toolchain install all
   cargo xtask toolchain setup cuda
@@ -1667,6 +1669,10 @@ pub enum ToolchainCommands {
 pub enum ToolchainComponent {
     /// Install every xtask-managed toolchain.
     All,
+    /// Install the hermetic Bun executable.
+    Bun,
+    /// Install the hermetic CMake executable.
+    Cmake,
     /// Install the hermetic uv executable.
     Uv,
     /// Install Ninja on platforms where xtask manages it.

--- a/xtask/src/doctor.rs
+++ b/xtask/src/doctor.rs
@@ -82,7 +82,7 @@ fn print_core_statuses() -> usize {
 
 fn print_node_statuses(ctx: &BuildContext) {
     output::phase("Node binding readiness");
-    optional_command_status("Bun", "bun", "Install Bun from https://bun.sh/").print();
+    toolchain::bun_status(ctx).print();
     toolchain::node_workspace_status(ctx).print();
     output::detail(
         "Recovery",
@@ -99,8 +99,9 @@ fn print_python_statuses(ctx: &BuildContext) {
 fn print_wasm_statuses(ctx: &BuildContext, include_js_workspace: bool) {
     output::phase("WASM/browser readiness");
     if include_js_workspace {
-        optional_command_status("Bun", "bun", "Install Bun from https://bun.sh/").print();
+        toolchain::bun_status(ctx).print();
     }
+    toolchain::cmake_status(ctx).print();
     toolchain::ninja_status(ctx).print();
     toolchain::emsdk_status(ctx).print();
     if include_js_workspace {
@@ -144,26 +145,6 @@ fn required_command_status(
         }
     } else {
         ToolStatus::Missing {
-            name,
-            detail: format!("{command} is not available on PATH"),
-            fix,
-        }
-    }
-}
-
-fn optional_command_status(
-    name: &'static str,
-    command: &'static str,
-    fix: &'static str,
-) -> ToolStatus {
-    if toolchain::has_command(command) {
-        ToolStatus::Ready {
-            name,
-            detail: format!("{command} is available"),
-            path: None,
-        }
-    } else {
-        ToolStatus::Warn {
             name,
             detail: format!("{command} is not available on PATH"),
             fix,

--- a/xtask/src/javascript.rs
+++ b/xtask/src/javascript.rs
@@ -1,6 +1,7 @@
 //! JavaScript package-manager helpers for xtask workflows.
 
 use crate::output;
+use crate::toolchains::bun::setup_bun;
 use crate::utils::BuildContext;
 use anyhow::{Context, Result};
 use serde_json::Value;
@@ -25,9 +26,10 @@ pub(crate) fn install_root_workspace_dependencies(
     label: impl Into<String>,
     package_dirs: &[PathBuf],
 ) -> Result<()> {
+    let bun_exe = setup_bun(sh, ctx)?;
     let filters = root_workspace_package_filters(package_dirs)?;
     let _dir = sh.push_dir(ctx.workspace_root());
-    let mut install_cmd = cmd!(sh, "bun install --frozen-lockfile");
+    let mut install_cmd = cmd!(sh, "{bun_exe} install --frozen-lockfile");
     for filter in &filters {
         install_cmd = install_cmd.arg("--filter").arg(filter);
     }
@@ -35,10 +37,11 @@ pub(crate) fn install_root_workspace_dependencies(
 }
 
 pub(crate) fn install_node_binding_dependencies(sh: &Shell, ctx: &BuildContext) -> Result<()> {
+    let bun_exe = setup_bun(sh, ctx)?;
     let _dir = sh.push_dir(ctx.bindings_node_dir());
     output::run_build_command(
         "Installing Node binding JavaScript dependencies",
-        cmd!(sh, "bun install --frozen-lockfile"),
+        cmd!(sh, "{bun_exe} install --frozen-lockfile"),
     )
 }
 

--- a/xtask/src/run.rs
+++ b/xtask/src/run.rs
@@ -13,6 +13,7 @@ use crate::javascript;
 use crate::output;
 use crate::sample_model::{self, SampleModelOptions};
 use crate::targets;
+use crate::toolchains::bun::setup_bun;
 use crate::toolchains::env::apply_toolchains;
 use crate::toolchains::python::{apply_uv_env, ensure_python, setup_uv, PYTHON_BUILD_VERSION};
 use crate::utils::BuildContext;
@@ -181,10 +182,11 @@ fn build_demo_only(sh: &Shell, ctx: &BuildContext, demo: DemoName) -> Result<()>
     output::path("Demo workspace", &demo_dir);
     output::path("Artifact directory", &ctx.demo_artifacts_dir(demo.slug()));
 
+    let bun_exe = setup_bun(sh, ctx)?;
     let _dir = sh.push_dir(&demo_dir);
     output::run_build_command(
         format!("Building {} demo", demo.slug()),
-        cmd!(sh, "bun run build"),
+        cmd!(sh, "{bun_exe} run build"),
     )
     .with_context(|| format!("failed to build {} demo", demo.slug()))
 }
@@ -206,9 +208,10 @@ fn serve_demo(sh: &Shell, ctx: &BuildContext, args: &RunDemoServeArgs) -> Result
 
     let demo_dir = ctx.demo_dir(args.demo.slug());
     let _dir = sh.push_dir(&demo_dir);
+    let bun_exe = setup_bun(sh, ctx)?;
     let mut serve_cmd = match args.mode {
-        DemoServeMode::Dev => cmd!(sh, "bunx --bun vite"),
-        DemoServeMode::Preview => cmd!(sh, "bunx --bun vite preview"),
+        DemoServeMode::Dev => cmd!(sh, "{bun_exe} x --bun vite"),
+        DemoServeMode::Preview => cmd!(sh, "{bun_exe} x --bun vite preview"),
     };
 
     if let Some(host) = &args.host {
@@ -242,10 +245,11 @@ fn build_tool_only(sh: &Shell, ctx: &BuildContext, tool: ToolName) -> Result<()>
     output::path("Tool workspace", &tool_dir);
     output::path("Artifact directory", &ctx.tool_artifacts_dir(tool.slug()));
 
+    let bun_exe = setup_bun(sh, ctx)?;
     let _dir = sh.push_dir(&tool_dir);
     output::run_build_command(
         format!("Building {} tool", tool.slug()),
-        cmd!(sh, "bun run build"),
+        cmd!(sh, "{bun_exe} run build"),
     )
     .with_context(|| format!("failed to build {} tool", tool.slug()))
 }
@@ -267,6 +271,7 @@ fn serve_tool(sh: &Shell, ctx: &BuildContext, args: &RunToolServeArgs) -> Result
 
     serve_vite_workspace(
         sh,
+        ctx,
         &tool_dir(ctx, args.tool),
         args.mode,
         args.host.as_deref(),
@@ -310,6 +315,7 @@ fn serve_browser_example(
 
     serve_vite_workspace(
         sh,
+        ctx,
         &example_dir(ctx, example),
         args.mode,
         args.host.as_deref(),
@@ -535,6 +541,7 @@ fn run_web_gateway_example(
 
     serve_vite_workspace(
         sh,
+        ctx,
         &example_dir(ctx, example),
         args.mode,
         Some(&args.host),
@@ -556,10 +563,11 @@ fn build_example_only(sh: &Shell, ctx: &BuildContext, example: ExampleName) -> R
         &ctx.example_artifacts_dir(example.dir_name()),
     );
 
+    let bun_exe = setup_bun(sh, ctx)?;
     let _dir = sh.push_dir(&example_dir);
     output::run_build_command(
         format!("Building {} example", example.label()),
-        cmd!(sh, "bun run build"),
+        cmd!(sh, "{bun_exe} run build"),
     )
     .with_context(|| format!("failed to build {} example", example.label()))
 }
@@ -1011,6 +1019,7 @@ fn format_temperature(temperature: f32) -> String {
 
 fn serve_vite_workspace(
     sh: &Shell,
+    ctx: &BuildContext,
     workspace: &Path,
     mode: DemoServeMode,
     host: Option<&str>,
@@ -1019,9 +1028,10 @@ fn serve_vite_workspace(
     error_context: String,
 ) -> Result<()> {
     let _dir = sh.push_dir(workspace);
+    let bun_exe = setup_bun(sh, ctx)?;
     let mut serve_cmd = match mode {
-        DemoServeMode::Dev => cmd!(sh, "bunx --bun vite"),
-        DemoServeMode::Preview => cmd!(sh, "bunx --bun vite preview"),
+        DemoServeMode::Dev => cmd!(sh, "{bun_exe} x --bun vite"),
+        DemoServeMode::Preview => cmd!(sh, "{bun_exe} x --bun vite preview"),
     };
 
     if let Some(host) = host {

--- a/xtask/src/setup/launcher.rs
+++ b/xtask/src/setup/launcher.rs
@@ -1,6 +1,7 @@
 //! Cached launcher installer for the short `sipp` developer command.
 
 use crate::output;
+use crate::toolchains::cmake;
 use crate::utils::BuildContext;
 use anyhow::{Context, Result};
 use std::env;
@@ -112,12 +113,12 @@ pub(crate) fn install(sh: &Shell, ctx: &BuildContext) -> Result<()> {
     write_launcher(&bin_dir.join("sipp"), &UNIX_LAUNCHER.replace("\r\n", "\n"))?;
     write_launcher(&bin_dir.join("sipp.cmd"), WINDOWS_CMD_LAUNCHER)?;
     write_launcher(&bin_dir.join("sipp.ps1"), WINDOWS_PS_LAUNCHER)?;
-    write_launcher(&bin_dir.join("sipp-env.sh"), &unix_env_script(&bin_dir))?;
+    write_launcher(&bin_dir.join("sipp-env.sh"), &unix_env_script(&bin_dir)?)?;
     write_launcher(
         &bin_dir.join("sipp-env.ps1"),
-        &powershell_env_script(&bin_dir),
+        &powershell_env_script(&bin_dir)?,
     )?;
-    write_launcher(&bin_dir.join("sipp-env.cmd"), &cmd_env_script(&bin_dir))?;
+    write_launcher(&bin_dir.join("sipp-env.cmd"), &cmd_env_script(&bin_dir)?)?;
     make_unix_launcher_executable(&bin_dir.join("sipp"))?;
     make_unix_launcher_executable(&bin_dir.join("sipp-env.sh"))?;
 
@@ -180,26 +181,52 @@ fn path_string_eq(left: &Path, right: &Path) -> bool {
     }
 }
 
-fn unix_env_script(bin_dir: &Path) -> String {
-    // Utilize the updated shell_quote that handles the drive letter conversion
+fn unix_env_script(bin_dir: &Path) -> Result<String> {
     let bin_dir_quoted = shell_quote(bin_dir);
+    let bun_dir_quoted = shell_quote(&toolchain_sibling_dir(bin_dir, "bun"));
+    let ninja_dir_quoted = shell_quote(&toolchain_sibling_dir(bin_dir, "ninja"));
+    let cmake_bin_dir_quoted = shell_quote(&cmake_bin_dir(bin_dir)?);
 
-    format!(
+    Ok(format!(
         r#"#!/usr/bin/env sh
 SIPP_BIN={bin_dir_quoted}
+SIPP_BUN={bun_dir_quoted}
+SIPP_NINJA={ninja_dir_quoted}
+SIPP_CMAKE_BIN={cmake_bin_dir_quoted}
 case ":${{PATH:-}}:" in
   *:"$SIPP_BIN":*) ;;
   *) export PATH="$SIPP_BIN${{PATH:+:$PATH}}" ;;
 esac
+case ":${{PATH:-}}:" in
+  *:"$SIPP_BUN":*) ;;
+  *) export PATH="$SIPP_BUN${{PATH:+:$PATH}}" ;;
+esac
+case ":${{PATH:-}}:" in
+  *:"$SIPP_NINJA":*) ;;
+  *) export PATH="$SIPP_NINJA${{PATH:+:$PATH}}" ;;
+esac
+case ":${{PATH:-}}:" in
+  *:"$SIPP_CMAKE_BIN":*) ;;
+  *) export PATH="$SIPP_CMAKE_BIN${{PATH:+:$PATH}}" ;;
+esac
 "#
     )
-    .replace("\r\n", "\n") // Force Unix line endings
+    .replace("\r\n", "\n"))
 }
 
-fn powershell_env_script(bin_dir: &Path) -> String {
+fn powershell_env_script(bin_dir: &Path) -> Result<String> {
+    let bun_dir = toolchain_sibling_dir(bin_dir, "bun");
+    let ninja_dir = toolchain_sibling_dir(bin_dir, "ninja");
+    let cmake_bin_dir = cmake_bin_dir(bin_dir)?;
     let bin_dir = powershell_quote_str(&bin_dir.display().to_string());
-    format!(
+    let bun_dir = powershell_quote_str(&bun_dir.display().to_string());
+    let ninja_dir = powershell_quote_str(&ninja_dir.display().to_string());
+    let cmake_bin_dir = powershell_quote_str(&cmake_bin_dir.display().to_string());
+    Ok(format!(
         r#"$SippBin = {bin_dir}
+$SippBun = {bun_dir}
+$SippNinja = {ninja_dir}
+$SippCmakeBin = {cmake_bin_dir}
 $PathParts = @()
 if ($env:Path) {{
   $PathParts = $env:Path -split [System.IO.Path]::PathSeparator
@@ -207,19 +234,55 @@ if ($env:Path) {{
 if ($PathParts -notcontains $SippBin) {{
   $env:Path = "$SippBin$([System.IO.Path]::PathSeparator)$env:Path"
 }}
+if ($PathParts -notcontains $SippBun) {{
+  $env:Path = "$SippBun$([System.IO.Path]::PathSeparator)$env:Path"
+}}
+if ($PathParts -notcontains $SippNinja) {{
+  $env:Path = "$SippNinja$([System.IO.Path]::PathSeparator)$env:Path"
+}}
+if ($PathParts -notcontains $SippCmakeBin) {{
+  $env:Path = "$SippCmakeBin$([System.IO.Path]::PathSeparator)$env:Path"
+}}
 "#
-    )
+    ))
 }
 
-fn cmd_env_script(bin_dir: &Path) -> String {
+fn cmd_env_script(bin_dir: &Path) -> Result<String> {
+    let bun_dir = toolchain_sibling_dir(bin_dir, "bun");
+    let ninja_dir = toolchain_sibling_dir(bin_dir, "ninja");
+    let cmake_bin_dir = cmake_bin_dir(bin_dir)?;
     let bin_dir = bin_dir.display().to_string().replace('%', "%%");
-    format!(
+    let bun_dir = bun_dir.display().to_string().replace('%', "%%");
+    let ninja_dir = ninja_dir.display().to_string().replace('%', "%%");
+    let cmake_bin_dir = cmake_bin_dir.display().to_string().replace('%', "%%");
+    Ok(format!(
         r#"@echo off
 set "SIPP_BIN={bin_dir}"
+set "SIPP_BUN={bun_dir}"
+set "SIPP_NINJA={ninja_dir}"
+set "SIPP_CMAKE_BIN={cmake_bin_dir}"
 echo ;%PATH%; | find /I ";%SIPP_BIN%;" >nul
 if errorlevel 1 set "PATH=%SIPP_BIN%;%PATH%"
+echo ;%PATH%; | find /I ";%SIPP_BUN%;" >nul
+if errorlevel 1 set "PATH=%SIPP_BUN%;%PATH%"
+echo ;%PATH%; | find /I ";%SIPP_NINJA%;" >nul
+if errorlevel 1 set "PATH=%SIPP_NINJA%;%PATH%"
+echo ;%PATH%; | find /I ";%SIPP_CMAKE_BIN%;" >nul
+if errorlevel 1 set "PATH=%SIPP_CMAKE_BIN%;%PATH%"
 "#
-    )
+    ))
+}
+
+fn toolchain_sibling_dir(bin_dir: &Path, name: &str) -> std::path::PathBuf {
+    bin_dir
+        .parent()
+        .map(|build_dir| build_dir.join("toolchain").join(name))
+        .unwrap_or_else(|| bin_dir.join("..").join("toolchain").join(name))
+}
+
+fn cmake_bin_dir(bin_dir: &Path) -> Result<std::path::PathBuf> {
+    let cmake_dir = toolchain_sibling_dir(bin_dir, "cmake");
+    cmake::cmake_bin_dir(&cmake_dir)
 }
 
 fn shell_quote(path: &Path) -> String {

--- a/xtask/src/setup/mod.rs
+++ b/xtask/src/setup/mod.rs
@@ -8,7 +8,7 @@ use crate::output;
 use crate::sample_model::{self, SampleModelOptions};
 use crate::terminal::splash;
 use crate::toolchain;
-use crate::toolchains::{emsdk, ninja, python, vulkan};
+use crate::toolchains::{bun, cmake, emsdk, ninja, python, source, vulkan};
 use crate::utils::BuildContext;
 use anyhow::{Context, Result};
 use console::Term;
@@ -212,6 +212,7 @@ fn run_downloads(
     }
 
     if downloads.contains(&SetupDownload::ManagedToolchains) {
+        source::ensure_llama_cpp_submodule(sh, ctx)?;
         install_managed_toolchains(sh, ctx, profile)?;
     }
     if downloads.contains(&SetupDownload::JavaScriptDependencies) {
@@ -228,14 +229,20 @@ fn install_managed_toolchains(sh: &Shell, ctx: &BuildContext, profile: SetupProf
     output::phase("Managed toolchains");
     match profile {
         SetupProfile::Browser => {
+            bun::setup_bun(sh, ctx)?;
+            cmake::setup_cmake(sh, ctx)?;
             ninja::setup_ninja(sh, ctx)?;
             emsdk::setup_emsdk(sh, ctx)?;
         }
         SetupProfile::Bindings => {
+            bun::setup_bun(sh, ctx)?;
+            cmake::setup_cmake(sh, ctx)?;
             python::setup_uv(sh, ctx)?;
             vulkan::setup_vulkan(sh, ctx)?;
         }
         SetupProfile::Full => {
+            bun::setup_bun(sh, ctx)?;
+            cmake::setup_cmake(sh, ctx)?;
             python::setup_uv(sh, ctx)?;
             ninja::setup_ninja(sh, ctx)?;
             emsdk::setup_emsdk(sh, ctx)?;

--- a/xtask/src/targets/gateway_server.rs
+++ b/xtask/src/targets/gateway_server.rs
@@ -3,6 +3,7 @@
 use crate::cli::Backend;
 use crate::javascript;
 use crate::output;
+use crate::toolchains::bun::setup_bun;
 use crate::toolchains::env::apply_toolchains;
 use crate::utils::BuildContext;
 use anyhow::{Context, Result};
@@ -108,10 +109,11 @@ fn build_admin_ui(sh: &Shell, ctx: &BuildContext) -> Result<PathBuf> {
         "Installing gateway Admin Dashboard dependencies",
         std::slice::from_ref(&admin_ui_dir),
     )?;
+    let bun_exe = setup_bun(sh, ctx)?;
     let _dir = sh.push_dir(ctx.workspace_root());
     output::run_build_command(
         "Building gateway Admin Dashboard",
-        cmd!(sh, "bun run --filter sipp-gateway-admin-ui build"),
+        cmd!(sh, "{bun_exe} run --filter sipp-gateway-admin-ui build"),
     )?;
     if !dist.join("index.html").is_file() {
         anyhow::bail!(

--- a/xtask/src/targets/node.rs
+++ b/xtask/src/targets/node.rs
@@ -3,6 +3,7 @@
 use crate::cli::Backend;
 use crate::javascript;
 use crate::output;
+use crate::toolchains::bun::setup_bun;
 use crate::toolchains::env::apply_toolchains;
 use crate::utils::BuildContext;
 use anyhow::{Context, Result};
@@ -145,9 +146,10 @@ fn build_backend_variant(
     output::path("Cargo target dir", &target_dir);
     output::path("Staging directory", &staging_dir);
 
+    let bun_exe = setup_bun(sh, ctx)?;
     let mut napi_cmd = cmd!(
         sh,
-        "bunx napi build --platform --release --no-js --output-dir {staging_dir} --target-dir {target_dir}"
+        "{bun_exe} x napi build --platform --release --no-js --output-dir {staging_dir} --target-dir {target_dir}"
     );
     napi_cmd = apply_toolchains(sh, ctx, napi_cmd, Some(backend))?;
 

--- a/xtask/src/targets/wasm.rs
+++ b/xtask/src/targets/wasm.rs
@@ -3,8 +3,11 @@
 use crate::cli::{WasmRuntime, WasmThreading};
 use crate::javascript;
 use crate::output;
+use crate::toolchains::bun::setup_bun;
+use crate::toolchains::cmake::setup_cmake;
 use crate::toolchains::emsdk::{run_with_emsdk, setup_emsdk};
 use crate::toolchains::ninja::setup_ninja;
+use crate::toolchains::source::ensure_llama_cpp_submodule;
 use crate::utils::BuildContext;
 use anyhow::Result;
 use std::path::Path;
@@ -24,7 +27,9 @@ pub fn build(
     output::path("Workspace", root);
     output::path("WASM artifact directory", &ctx.npm_browser_wasm_dir());
 
+    ensure_llama_cpp_submodule(sh, ctx)?;
     let emsdk_dir = setup_emsdk(sh, ctx)?;
+    let cmake_bin_dir = setup_cmake(sh, ctx)?;
     let ninja_dir = setup_ninja(sh, ctx)?;
 
     let npm_dist_wasm = ctx.npm_browser_wasm_dir();
@@ -44,6 +49,7 @@ pub fn build(
                 ctx,
                 root,
                 &emsdk_dir,
+                &cmake_bin_dir,
                 ninja_dir.as_deref(),
                 false,
                 runtime_flavor,
@@ -59,6 +65,7 @@ pub fn build(
                 ctx,
                 root,
                 &emsdk_dir,
+                &cmake_bin_dir,
                 ninja_dir.as_deref(),
                 true,
                 runtime_flavor,
@@ -69,6 +76,7 @@ pub fn build(
 
     output::phase("TypeScript browser package");
     let npm_workspace = ctx.browser_package_dir();
+    let bun_exe = setup_bun(sh, ctx)?;
     output::path("Browser package workspace", &npm_workspace);
 
     javascript::install_root_workspace_dependencies(
@@ -81,9 +89,12 @@ pub fn build(
     let _npm_dir = sh.push_dir(&npm_workspace);
     output::run_build_command(
         "Compiling TypeScript wrappers",
-        cmd!(sh, "bun run build:ts"),
+        cmd!(sh, "{bun_exe} run build:ts"),
     )?;
-    output::run_build_command("Staging browser package", cmd!(sh, "bun run build:stage"))?;
+    output::run_build_command(
+        "Staging browser package",
+        cmd!(sh, "{bun_exe} run build:stage"),
+    )?;
 
     output::success(format!(
         "WASM pipeline complete in {}",
@@ -134,6 +145,7 @@ fn build_target(
     ctx: &BuildContext,
     root: &Path,
     emsdk_dir: &Path,
+    cmake_bin_dir: &Path,
     ninja_dir: Option<&Path>,
     use_pthreads: bool,
     runtime_flavor: WasmRuntimeFlavor,
@@ -179,6 +191,7 @@ fn build_target(
     run_with_emsdk(
         sh,
         emsdk_dir,
+        Some(cmake_bin_dir),
         ninja_dir,
         &format!("Compiling Rust staticlib for {js_file}"),
         &cargo_cmd,
@@ -220,6 +233,7 @@ fn build_target(
     run_with_emsdk(
         sh,
         emsdk_dir,
+        Some(cmake_bin_dir),
         ninja_dir,
         &format!("Configuring CMake for {artifact_name}"),
         &emcmake_cmd,
@@ -229,6 +243,7 @@ fn build_target(
     run_with_emsdk(
         sh,
         emsdk_dir,
+        Some(cmake_bin_dir),
         ninja_dir,
         &format!("Building browser runtime for {artifact_name}"),
         build_cmd,

--- a/xtask/src/test.rs
+++ b/xtask/src/test.rs
@@ -13,6 +13,7 @@ use crate::javascript;
 use crate::output;
 use crate::sample_model::{self, SampleModelOptions};
 use crate::targets;
+use crate::toolchains::bun::setup_bun;
 use crate::toolchains::env::apply_toolchains;
 use crate::toolchains::python::{apply_uv_env, ensure_python, setup_uv, PYTHON_BUILD_VERSION};
 use crate::utils::{ensure_playwright_chromium, BuildContext};
@@ -1026,6 +1027,7 @@ fn run_node_package_tests(
 
     let node_dir = ctx.node_package_dir();
     ensure_javascript_workspace_dependencies(sh, ctx, &[node_dir.clone()])?;
+    let bun_exe = setup_bun(sh, ctx)?;
     let _node = sh.push_dir(&node_dir);
     for backend in node_test_backends(ctx, backend)? {
         let report_path = suite_case_report_file(
@@ -1036,7 +1038,7 @@ fn run_node_package_tests(
         let mut test_cmd = if coverage_enabled {
             cmd!(
                 sh,
-                "bunx c8 --reporter=lcov --reports-dir {coverage_dir} node --test --test-reporter=tap --test-reporter-destination {report_path} tests/router.test.mjs"
+                "{bun_exe} x c8 --reporter=lcov --reports-dir {coverage_dir} node --test --test-reporter=tap --test-reporter-destination {report_path} tests/router.test.mjs"
             )
         } else {
             cmd!(

--- a/xtask/src/tests/cli_tests.rs
+++ b/xtask/src/tests/cli_tests.rs
@@ -589,6 +589,24 @@ fn toolchain_doctor_and_setup_commands_parse() {
     };
     assert_eq!(component, ToolchainComponent::Vulkan);
 
+    let cli = Cli::parse_from(["xtask", "toolchain", "install", "bun"]);
+    let Commands::Toolchain { command } = cli.command else {
+        panic!("expected toolchain command");
+    };
+    let ToolchainCommands::Install { component } = command else {
+        panic!("expected toolchain install command");
+    };
+    assert_eq!(component, ToolchainComponent::Bun);
+
+    let cli = Cli::parse_from(["xtask", "toolchain", "install", "cmake"]);
+    let Commands::Toolchain { command } = cli.command else {
+        panic!("expected toolchain command");
+    };
+    let ToolchainCommands::Install { component } = command else {
+        panic!("expected toolchain install command");
+    };
+    assert_eq!(component, ToolchainComponent::Cmake);
+
     let cli = Cli::parse_from(["xtask", "doctor", "--target", "python", "--backend", "all"]);
     let Commands::Doctor(args) = cli.command else {
         panic!("expected doctor command");

--- a/xtask/src/tests/doctor_tests.rs
+++ b/xtask/src/tests/doctor_tests.rs
@@ -8,7 +8,7 @@ use crate::toolchain::ToolStatus;
 
 use super::{
     doctor_target_label, includes_core, includes_native_backend, includes_node, includes_python,
-    includes_wasm, metal_status, optional_command_status, required_command_status,
+    includes_wasm, metal_status, required_command_status,
 };
 
 #[test]
@@ -35,10 +35,9 @@ fn doctor_labels_are_stable() {
 }
 
 #[test]
-fn command_status_helpers_distinguish_required_and_optional_missing_tools() {
+fn required_command_status_reports_missing_tools() {
     let missing = "sipp-definitely-not-installed-command";
     let required = required_command_status("Required", missing, "fix required");
-    let optional = optional_command_status("Optional", missing, "fix optional");
 
     assert!(matches!(
         required,
@@ -48,14 +47,6 @@ fn command_status_helpers_distinguish_required_and_optional_missing_tools() {
         }
     ));
     assert!(required.is_missing());
-    assert!(matches!(
-        optional,
-        ToolStatus::Warn {
-            name: "Optional",
-            ..
-        }
-    ));
-    assert!(!optional.is_missing());
 }
 
 #[test]

--- a/xtask/src/tests/setup/launcher_tests.rs
+++ b/xtask/src/tests/setup/launcher_tests.rs
@@ -31,18 +31,33 @@ fn powershell_and_cmd_quotes_escape_shell_specific_characters() {
 
 #[test]
 fn env_scripts_prepend_launcher_directory_once() {
-    let bin = Path::new("D:\\Sipp\\.build\\bin");
-    let unix = unix_env_script(bin);
+    let bin = Path::new("/tmp/Sipp/.build/bin");
+    let unix = unix_env_script(bin).unwrap();
     assert!(unix.contains("SIPP_BIN="));
+    assert!(unix.contains("SIPP_BUN="));
+    assert!(unix.contains("SIPP_NINJA="));
+    assert!(unix.contains("SIPP_CMAKE_BIN="));
+    assert!(unix.contains(".build/toolchain/bun"));
+    assert!(unix.contains(".build/toolchain/ninja"));
+    assert!(unix.contains(".build/toolchain/cmake"));
     assert!(unix.contains("export PATH="));
     assert!(!unix.contains("\r\n"));
 
-    let powershell = powershell_env_script(bin);
+    let powershell = powershell_env_script(bin).unwrap();
     assert!(powershell.contains("$SippBin"));
+    assert!(powershell.contains("$SippBun"));
+    assert!(powershell.contains("$SippNinja"));
+    assert!(powershell.contains("$SippCmakeBin"));
+    assert!(powershell.contains(".build/toolchain/bun"));
+    assert!(powershell.contains(".build/toolchain/ninja"));
+    assert!(powershell.contains(".build/toolchain/cmake"));
     assert!(powershell.contains("[System.IO.Path]::PathSeparator"));
 
-    let cmd = cmd_env_script(Path::new("C:\\100%\\bin"));
+    let cmd = cmd_env_script(Path::new("C:\\100%\\bin")).unwrap();
     assert!(cmd.contains("C:\\100%%\\bin"));
+    assert!(cmd.contains("SIPP_BUN"));
+    assert!(cmd.contains("SIPP_NINJA"));
+    assert!(cmd.contains("SIPP_CMAKE_BIN"));
     assert!(cmd.contains("PATH=%SIPP_BIN%;%PATH%"));
 }
 

--- a/xtask/src/tests/toolchain_tests.rs
+++ b/xtask/src/tests/toolchain_tests.rs
@@ -10,8 +10,8 @@ use crate::toolchains::vulkan::VULKAN_VERSION;
 use crate::utils::BuildContext;
 
 use super::{
-    component_label, cuda_status, emsdk_status, node_modules_roots, node_workspace_status,
-    uv_status, vulkan_glslc_path, vulkan_status, ToolStatus,
+    bun_status, cmake_status, component_label, cuda_status, emsdk_status, node_modules_roots,
+    node_workspace_status, uv_status, vulkan_glslc_path, vulkan_status, ToolStatus,
 };
 
 #[test]
@@ -19,6 +19,14 @@ fn managed_statuses_report_missing_fake_toolchains() {
     let temp = TempDir::new("toolchain-missing");
     let ctx = BuildContext::from_workspace_root_for_test(temp.path());
 
+    assert!(matches!(
+        bun_status(&ctx),
+        ToolStatus::Missing { name: "Bun", .. }
+    ));
+    assert!(matches!(
+        cmake_status(&ctx),
+        ToolStatus::Missing { name: "CMake", .. }
+    ));
     assert!(matches!(
         uv_status(&ctx),
         ToolStatus::Missing { name: "uv", .. }
@@ -139,6 +147,8 @@ fn node_workspace_status_checks_every_workspace_node_modules_root() {
 #[test]
 fn component_labels_match_cli_values() {
     assert_eq!(component_label(&ToolchainComponent::All), "all");
+    assert_eq!(component_label(&ToolchainComponent::Bun), "bun");
+    assert_eq!(component_label(&ToolchainComponent::Cmake), "cmake");
     assert_eq!(component_label(&ToolchainComponent::Uv), "uv");
     assert_eq!(component_label(&ToolchainComponent::Ninja), "ninja");
     assert_eq!(component_label(&ToolchainComponent::Emsdk), "emsdk");

--- a/xtask/src/tests/toolchains/bun_tests.rs
+++ b/xtask/src/tests/toolchains/bun_tests.rs
@@ -1,0 +1,36 @@
+//! Tests the `toolchains::bun` module in `xtask`.
+//!
+//! Covers managed Bun version detection using small fake executables instead of
+//! downloading Bun from GitHub.
+
+#[cfg(unix)]
+use crate::test_support::TempDir;
+
+use super::{bun_version_matches, BUN_VERSION};
+
+#[cfg(unix)]
+#[test]
+fn bun_version_matching_requires_pinned_version() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let temp = TempDir::new("bun-version");
+    let old_bun = temp.write("old-bun", "#!/usr/bin/env sh\necho 0.0.0\n");
+    let current_bun = temp.write(
+        "current-bun",
+        format!("#!/usr/bin/env sh\necho {BUN_VERSION}\n"),
+    );
+    let mut permissions = std::fs::metadata(&old_bun).unwrap().permissions();
+    permissions.set_mode(0o755);
+    std::fs::set_permissions(&old_bun, permissions.clone()).unwrap();
+    std::fs::set_permissions(&current_bun, permissions).unwrap();
+
+    assert!(!bun_version_matches(&old_bun));
+    assert!(bun_version_matches(&current_bun));
+}
+
+#[test]
+fn missing_bun_does_not_match_pinned_version() {
+    assert!(!bun_version_matches(std::path::Path::new(
+        "sipp-missing-bun"
+    )));
+}

--- a/xtask/src/tests/toolchains/emsdk_tests.rs
+++ b/xtask/src/tests/toolchains/emsdk_tests.rs
@@ -6,7 +6,8 @@
 use crate::test_support::TempDir;
 
 use super::{
-    emsdk_is_active, emsdk_is_installed, expected_emsdk_tool_id, patch_emsdk_windows, EMSDK_VERSION,
+    emsdk_is_active, emsdk_is_installed, expected_emsdk_tool_id, patch_emsdk_windows,
+    rust_target_list_contains, EMSDK_VERSION,
 };
 
 #[test]
@@ -53,6 +54,17 @@ fn installed_check_rejects_wrong_version_marker() {
     temp.write("upstream/.emsdk_version", "other\n");
 
     assert!(!emsdk_is_installed(temp.path()).unwrap());
+}
+
+#[test]
+fn rust_target_list_matching_requires_exact_line() {
+    let installed = "aarch64-apple-darwin\nwasm32-unknown-emscripten\n";
+
+    assert!(rust_target_list_contains(
+        installed,
+        "wasm32-unknown-emscripten"
+    ));
+    assert!(!rust_target_list_contains(installed, "wasm32-unknown"));
 }
 
 #[test]

--- a/xtask/src/tests/toolchains/env_tests.rs
+++ b/xtask/src/tests/toolchains/env_tests.rs
@@ -1,9 +1,13 @@
 //! Tests the `toolchains::env` module in `xtask`.
 //!
-//! Covers deterministic platform path-separator selection without constructing
-//! commands that would bootstrap or inspect external toolchains.
+//! Covers deterministic platform path-separator selection and native command
+//! environment setup without downloading external toolchains.
 
-use super::{macos_deployment_target, path_separator};
+use crate::test_support::TempDir;
+use crate::utils::BuildContext;
+use xshell::cmd;
+
+use super::{apply_toolchains, macos_deployment_target, path_separator};
 
 #[test]
 fn path_separator_matches_host_platform() {
@@ -23,4 +27,15 @@ fn macos_deployment_target_matches_host_architecture() {
     };
 
     assert_eq!(macos_deployment_target(), expected);
+}
+
+#[test]
+fn native_toolchain_env_does_not_install_missing_ninja() {
+    let temp = TempDir::new("env-no-ninja-install");
+    let ctx = BuildContext::from_workspace_root_for_test(temp.path());
+    let sh = xshell::Shell::new().unwrap();
+
+    let _command = apply_toolchains(&sh, &ctx, cmd!(sh, "true"), None).unwrap();
+
+    assert!(!ctx.ninja_toolchain_dir().exists());
 }

--- a/xtask/src/toolchain.rs
+++ b/xtask/src/toolchain.rs
@@ -2,7 +2,7 @@
 
 use crate::cli::{ToolchainCommands, ToolchainComponent, ToolchainSetupComponent};
 use crate::output;
-use crate::toolchains::{cuda, emsdk, ninja, python, vulkan};
+use crate::toolchains::{bun, cmake, cuda, emsdk, ninja, python, vulkan};
 use crate::utils::BuildContext;
 use anyhow::Result;
 use std::env;
@@ -97,10 +97,18 @@ fn install(sh: &Shell, ctx: &BuildContext, component: ToolchainComponent) -> Res
 
     match component {
         ToolchainComponent::All => {
+            bun::setup_bun(sh, ctx)?;
+            cmake::setup_cmake(sh, ctx)?;
             python::setup_uv(sh, ctx)?;
             ninja::setup_ninja(sh, ctx)?;
             emsdk::setup_emsdk(sh, ctx)?;
             vulkan::setup_vulkan(sh, ctx)?;
+        }
+        ToolchainComponent::Bun => {
+            bun::setup_bun(sh, ctx)?;
+        }
+        ToolchainComponent::Cmake => {
+            cmake::setup_cmake(sh, ctx)?;
         }
         ToolchainComponent::Uv => {
             python::setup_uv(sh, ctx)?;
@@ -122,6 +130,8 @@ fn install(sh: &Shell, ctx: &BuildContext, component: ToolchainComponent) -> Res
 
 pub(crate) fn managed_statuses(ctx: &BuildContext) -> Vec<ToolStatus> {
     vec![
+        bun_status(ctx),
+        cmake_status(ctx),
         uv_status(ctx),
         ninja_status(ctx),
         emsdk_status(ctx),
@@ -143,16 +153,71 @@ pub(crate) fn external_statuses(ctx: &BuildContext) -> Vec<ToolStatus> {
             ["--version"],
             "Install Rust from https://rustup.rs/",
         ),
-        command_status(
-            "Bun",
-            "bun",
-            ["--version"],
-            "Install Bun from https://bun.sh/",
-        ),
         cuda_status(ctx),
         node_workspace_status(ctx),
         docker_status(),
     ]
+}
+
+pub(crate) fn cmake_status(ctx: &BuildContext) -> ToolStatus {
+    let cmake_exe = match ctx.cmake_exe() {
+        Ok(cmake_exe) => cmake_exe,
+        Err(error) => {
+            return ToolStatus::Missing {
+                name: "CMake",
+                detail: error.to_string(),
+                fix: "Run `cargo xtask toolchain install cmake`",
+            };
+        }
+    };
+    if cmake_exe.exists() {
+        return command_path_status(
+            "CMake",
+            &cmake_exe,
+            ["--version"],
+            "Run `cargo xtask toolchain install cmake`",
+        );
+    }
+
+    ToolStatus::Missing {
+        name: "CMake",
+        detail: "managed CMake executable is missing".to_owned(),
+        fix: "Run `cargo xtask toolchain install cmake`",
+    }
+}
+
+pub(crate) fn bun_status(ctx: &BuildContext) -> ToolStatus {
+    let bun_exe = ctx.bun_exe();
+    if bun_exe.exists() {
+        let Some(version) = bun::bun_version(&bun_exe) else {
+            return ToolStatus::Missing {
+                name: "Bun",
+                detail: format!("{} exists but did not run successfully", bun_exe.display()),
+                fix: "Run `cargo xtask toolchain install bun`",
+            };
+        };
+        if version == bun::BUN_VERSION {
+            return ToolStatus::Ready {
+                name: "Bun",
+                detail: version,
+                path: Some(bun_exe),
+            };
+        }
+        return ToolStatus::Missing {
+            name: "Bun",
+            detail: format!(
+                "managed Bun version is {version}; expected {}",
+                bun::BUN_VERSION
+            ),
+            fix: "Run `cargo xtask toolchain install bun`",
+        };
+    }
+
+    ToolStatus::Missing {
+        name: "Bun",
+        detail: "managed Bun executable is missing".to_owned(),
+        fix: "Run `cargo xtask toolchain install bun`",
+    }
 }
 
 pub(crate) fn uv_status(ctx: &BuildContext) -> ToolStatus {
@@ -174,30 +239,21 @@ pub(crate) fn uv_status(ctx: &BuildContext) -> ToolStatus {
 }
 
 pub(crate) fn ninja_status(ctx: &BuildContext) -> ToolStatus {
-    if cfg!(windows) {
-        let ninja_exe = ctx.ninja_exe();
-        if ninja_exe.exists() {
-            return command_path_status(
-                "Ninja",
-                &ninja_exe,
-                ["--version"],
-                "Run `cargo xtask toolchain install ninja`",
-            );
-        }
-
-        return ToolStatus::Missing {
-            name: "Ninja",
-            detail: "managed Windows Ninja executable is missing".to_owned(),
-            fix: "Run `cargo xtask toolchain install ninja`",
-        };
+    let ninja_exe = ctx.ninja_exe();
+    if ninja_exe.exists() {
+        return command_path_status(
+            "Ninja",
+            &ninja_exe,
+            ["--version"],
+            "Run `cargo xtask toolchain install ninja`",
+        );
     }
 
-    command_status(
-        "Ninja",
-        "ninja",
-        ["--version"],
-        "Install Ninja with the host package manager",
-    )
+    ToolStatus::Missing {
+        name: "Ninja",
+        detail: "managed Ninja executable is missing".to_owned(),
+        fix: "Run `cargo xtask toolchain install ninja`",
+    }
 }
 
 pub(crate) fn emsdk_status(ctx: &BuildContext) -> ToolStatus {
@@ -452,6 +508,8 @@ fn setup_component(ctx: &BuildContext, component: ToolchainSetupComponent) -> Re
 fn component_label(component: &ToolchainComponent) -> &'static str {
     match component {
         ToolchainComponent::All => "all",
+        ToolchainComponent::Bun => "bun",
+        ToolchainComponent::Cmake => "cmake",
         ToolchainComponent::Uv => "uv",
         ToolchainComponent::Ninja => "ninja",
         ToolchainComponent::Emsdk => "emsdk",

--- a/xtask/src/toolchains/bun.rs
+++ b/xtask/src/toolchains/bun.rs
@@ -1,0 +1,154 @@
+//! Bun JavaScript runtime bootstrapping.
+
+use crate::output;
+use crate::utils::BuildContext;
+use anyhow::{Context, Result};
+use std::env;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use xshell::{cmd, Shell};
+
+/////////////////////////////////////////////////////////////////////////////////
+/// TESTS
+/////////////////////////////////////////////////////////////////////////////////
+
+#[cfg(test)]
+#[path = "../tests/toolchains/bun_tests.rs"]
+mod bun_tests;
+
+/////////////////////////////////////////////////////////////////////////////////
+/// SRC
+/////////////////////////////////////////////////////////////////////////////////
+
+pub(crate) const BUN_VERSION: &str = "1.3.14";
+
+/// Ensures the hermetic Bun executable is available under `.build/toolchain`.
+pub(crate) fn setup_bun(sh: &Shell, ctx: &BuildContext) -> Result<PathBuf> {
+    let bun_dir = ctx.bun_toolchain_dir();
+    let bun_exe = ctx.bun_exe();
+
+    if !bun_exe.exists() || !bun_version_matches(&bun_exe) {
+        output::phase("Bun JavaScript toolchain");
+        output::detail("Version", BUN_VERSION);
+        output::path("Install directory", &bun_dir);
+        sh.create_dir(&bun_dir)?;
+
+        let target = bun_target()?;
+        let filename = format!("{target}.zip");
+        let url = format!(
+            "https://github.com/oven-sh/bun/releases/download/bun-v{BUN_VERSION}/{filename}"
+        );
+        let archive_path = bun_dir.join(&filename);
+        if bun_exe.exists() {
+            sh.remove_path(&bun_exe)?;
+        }
+
+        output::detail("Download", &url);
+        output::run_command(
+            "Downloading Bun",
+            cmd!(sh, "curl -f -L -o {archive_path} {url}"),
+        )?;
+
+        if cfg!(windows) {
+            output::run_command(
+                "Extracting Bun",
+                cmd!(sh, "tar -xf {archive_path} -C {bun_dir}"),
+            )?;
+        } else {
+            output::run_command(
+                "Extracting Bun",
+                cmd!(sh, "unzip -oq {archive_path} -d {bun_dir}"),
+            )?;
+        }
+
+        let nested_bun_exe = bun_dir.join(target).join(bun_executable_name());
+        if nested_bun_exe.exists() {
+            sh.copy_file(&nested_bun_exe, &bun_exe)
+                .with_context(|| format!("failed to stage Bun at {}", bun_exe.display()))?;
+            make_unix_executable(&bun_exe)?;
+        } else if !bun_exe.exists() {
+            anyhow::bail!(
+                "Bun archive contained neither {} nor {}",
+                nested_bun_exe.display(),
+                bun_exe.display()
+            );
+        }
+
+        sh.remove_path(&archive_path)?;
+        let extracted_dir = bun_dir.join(target);
+        if extracted_dir.exists() {
+            sh.remove_path(extracted_dir)?;
+        }
+        output::success(format!("Installed Bun at {}", bun_exe.display()));
+    } else {
+        output::success(format!("Using Bun at {}", bun_exe.display()));
+    }
+
+    prepend_to_path(&bun_dir)?;
+
+    Ok(bun_exe)
+}
+
+pub(crate) fn bun_version_matches(path: &Path) -> bool {
+    bun_version(path).as_deref() == Some(BUN_VERSION)
+}
+
+pub(crate) fn bun_version(path: &Path) -> Option<String> {
+    let output = Command::new(path).arg("--version").output().ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    Some(String::from_utf8_lossy(&output.stdout).trim().to_owned())
+}
+
+fn bun_target() -> Result<&'static str> {
+    if cfg!(target_os = "windows") && cfg!(target_arch = "x86_64") {
+        Ok("bun-windows-x64")
+    } else if cfg!(target_os = "macos") && cfg!(target_arch = "aarch64") {
+        Ok("bun-darwin-aarch64")
+    } else if cfg!(target_os = "macos") && cfg!(target_arch = "x86_64") {
+        Ok("bun-darwin-x64")
+    } else if cfg!(target_os = "linux") && cfg!(target_arch = "aarch64") {
+        Ok("bun-linux-aarch64")
+    } else if cfg!(target_os = "linux") && cfg!(target_arch = "x86_64") {
+        Ok("bun-linux-x64")
+    } else {
+        anyhow::bail!("managed Bun is not available for this host platform")
+    }
+}
+
+fn bun_executable_name() -> &'static str {
+    if cfg!(windows) {
+        "bun.exe"
+    } else {
+        "bun"
+    }
+}
+
+fn prepend_to_path(dir: &Path) -> Result<()> {
+    let current = env::var_os("PATH").unwrap_or_default();
+    let mut paths = env::split_paths(&current).collect::<Vec<_>>();
+    if !paths.iter().any(|path| path == dir) {
+        paths.insert(0, dir.to_path_buf());
+        let joined = env::join_paths(paths).context("failed to update PATH for managed Bun")?;
+        env::set_var("PATH", joined);
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn make_unix_executable(path: &Path) -> Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+
+    let mut permissions = std::fs::metadata(path)
+        .with_context(|| format!("failed to inspect {}", path.display()))?
+        .permissions();
+    permissions.set_mode(0o755);
+    std::fs::set_permissions(path, permissions)
+        .with_context(|| format!("failed to mark {} executable", path.display()))
+}
+
+#[cfg(not(unix))]
+fn make_unix_executable(_path: &Path) -> Result<()> {
+    Ok(())
+}

--- a/xtask/src/toolchains/cmake.rs
+++ b/xtask/src/toolchains/cmake.rs
@@ -1,0 +1,88 @@
+//! CMake bootstrapping.
+
+use crate::output;
+use crate::utils::BuildContext;
+use anyhow::Result;
+use std::path::{Path, PathBuf};
+use xshell::{cmd, Shell};
+
+pub(crate) const CMAKE_VERSION: &str = "3.30.5";
+
+/// Ensures a hermetic CMake install is available under `.build/toolchain`.
+pub(crate) fn setup_cmake(sh: &Shell, ctx: &BuildContext) -> Result<PathBuf> {
+    let cmake_dir = ctx.cmake_toolchain_dir();
+    let cmake_bin_dir = ctx.cmake_bin_dir()?;
+    let cmake_exe = ctx.cmake_exe()?;
+
+    if !cmake_exe.exists() {
+        output::phase("CMake build tool");
+        output::detail("Version", CMAKE_VERSION);
+        output::path("Install directory", &cmake_dir);
+        sh.create_dir(&cmake_dir)?;
+
+        let filename = cmake_filename()?;
+        let url = format!(
+            "https://github.com/Kitware/CMake/releases/download/v{CMAKE_VERSION}/{filename}"
+        );
+        let archive_path = cmake_dir.join(filename);
+
+        output::detail("Download", &url);
+        output::run_command(
+            "Downloading CMake",
+            cmd!(sh, "curl -f -L -o {archive_path} {url}"),
+        )?;
+
+        if cfg!(windows) {
+            output::run_command(
+                "Extracting CMake",
+                cmd!(sh, "tar -xf {archive_path} -C {cmake_dir}"),
+            )?;
+        } else {
+            output::run_command(
+                "Extracting CMake",
+                cmd!(sh, "tar -xzf {archive_path} -C {cmake_dir}"),
+            )?;
+        }
+        sh.remove_path(archive_path)?;
+    } else {
+        output::success(format!("Using CMake at {}", cmake_exe.display()));
+    }
+
+    Ok(cmake_bin_dir)
+}
+
+fn cmake_filename() -> Result<String> {
+    let platform = cmake_archive_platform()?;
+    let extension = if cfg!(windows) { "zip" } else { "tar.gz" };
+    Ok(format!("cmake-{CMAKE_VERSION}-{platform}.{extension}"))
+}
+
+pub(crate) fn cmake_bin_dir(cmake_dir: &Path) -> Result<PathBuf> {
+    let install_dir = cmake_install_dir(cmake_dir)?;
+    if cfg!(target_os = "macos") {
+        Ok(install_dir.join("CMake.app").join("Contents").join("bin"))
+    } else {
+        Ok(install_dir.join("bin"))
+    }
+}
+
+pub(crate) fn cmake_install_dir(cmake_dir: &Path) -> Result<PathBuf> {
+    Ok(cmake_dir.join(format!(
+        "cmake-{CMAKE_VERSION}-{}",
+        cmake_archive_platform()?
+    )))
+}
+
+pub(crate) fn cmake_archive_platform() -> Result<&'static str> {
+    if cfg!(target_os = "windows") && cfg!(target_arch = "x86_64") {
+        Ok("windows-x86_64")
+    } else if cfg!(target_os = "macos") {
+        Ok("macos-universal")
+    } else if cfg!(target_os = "linux") && cfg!(target_arch = "x86_64") {
+        Ok("linux-x86_64")
+    } else if cfg!(target_os = "linux") && cfg!(target_arch = "aarch64") {
+        Ok("linux-aarch64")
+    } else {
+        anyhow::bail!("managed CMake is not available for this host platform")
+    }
+}

--- a/xtask/src/toolchains/emsdk.rs
+++ b/xtask/src/toolchains/emsdk.rs
@@ -4,6 +4,7 @@ use crate::output;
 use crate::utils::BuildContext;
 use anyhow::{bail, Context, Result};
 use std::path::Path;
+use std::process::Command;
 use std::thread;
 use std::time::Duration;
 use xshell::{cmd, Cmd, Shell};
@@ -21,6 +22,7 @@ mod emsdk_tests;
 /////////////////////////////////////////////////////////////////////////////////
 
 const EMSDK_VERSION: &str = "4.0.23";
+const RUST_EMSCRIPTEN_TARGET: &str = "wasm32-unknown-emscripten";
 
 /// Ensures the configured Emscripten SDK is cloned, installed, and active.
 pub(crate) fn setup_emsdk(sh: &Shell, ctx: &BuildContext) -> Result<std::path::PathBuf> {
@@ -61,6 +63,8 @@ pub(crate) fn setup_emsdk(sh: &Shell, ctx: &BuildContext) -> Result<std::path::P
         )?;
     }
 
+    ensure_rust_emscripten_target(sh)?;
+
     Ok(emsdk_dir)
 }
 
@@ -68,6 +72,7 @@ pub(crate) fn setup_emsdk(sh: &Shell, ctx: &BuildContext) -> Result<std::path::P
 pub(crate) fn run_with_emsdk(
     sh: &Shell,
     emsdk_dir: &Path,
+    cmake_bin_dir: Option<&Path>,
     ninja_dir: Option<&Path>,
     label: &str,
     command: &str,
@@ -76,11 +81,13 @@ pub(crate) fn run_with_emsdk(
         let bat = emsdk_dir.join("emsdk_env.bat");
         let temp_script = sh.current_dir().join(".run_emsdk_wrapper.bat");
 
-        let path_injection = if let Some(ninja_dir) = ninja_dir {
-            format!("set PATH={};%PATH%\r\n", ninja_dir.display())
-        } else {
-            String::new()
-        };
+        let mut path_injection = String::new();
+        if let Some(cmake_bin_dir) = cmake_bin_dir {
+            path_injection.push_str(&format!("set PATH={};%PATH%\r\n", cmake_bin_dir.display()));
+        }
+        if let Some(ninja_dir) = ninja_dir {
+            path_injection.push_str(&format!("set PATH={};%PATH%\r\n", ninja_dir.display()));
+        }
 
         let emcmake = emsdk_dir
             .join("upstream")
@@ -121,9 +128,24 @@ pub(crate) fn run_with_emsdk(
             .join("emcmake");
         let emmake = emsdk_dir.join("upstream").join("emscripten").join("emmake");
 
+        let mut path_exports = String::new();
+        if let Some(cmake_bin_dir) = cmake_bin_dir {
+            path_exports.push_str(&format!(
+                "export PATH=\"{}:$PATH\" && ",
+                cmake_bin_dir.display()
+            ));
+        }
+        if let Some(ninja_dir) = ninja_dir {
+            path_exports.push_str(&format!(
+                "export PATH=\"{}:$PATH\" && ",
+                ninja_dir.display()
+            ));
+        }
+
         let full_cmd = format!(
-            "source \"{}\" && export EMCMAKE=\"{}\" && export EMMAKE=\"{}\" && {}",
+            "source \"{}\" && {}export EMCMAKE=\"{}\" && export EMMAKE=\"{}\" && {}",
             script,
+            path_exports,
             emcmake.display(),
             emmake.display(),
             command
@@ -220,6 +242,38 @@ fn expected_emsdk_tool_id(emsdk_dir: &Path) -> Result<String> {
         .with_context(|| format!("emsdk release {EMSDK_VERSION} is not listed"))?;
 
     Ok(format!("releases-{release_hash}-64bit"))
+}
+
+fn ensure_rust_emscripten_target(sh: &Shell) -> Result<()> {
+    if rust_target_is_installed(RUST_EMSCRIPTEN_TARGET)? {
+        output::success(format!("Using Rust target {RUST_EMSCRIPTEN_TARGET}"));
+        return Ok(());
+    }
+
+    output::run_command(
+        format!("Installing Rust target {RUST_EMSCRIPTEN_TARGET}"),
+        cmd!(sh, "rustup target add {RUST_EMSCRIPTEN_TARGET}"),
+    )
+}
+
+fn rust_target_is_installed(target: &str) -> Result<bool> {
+    let output = Command::new("rustup")
+        .args(["target", "list", "--installed"])
+        .output()
+        .with_context(|| {
+            format!("failed to check installed Rust targets with `rustup`; install {target}")
+        })?;
+
+    if !output.status.success() {
+        bail!("failed to check installed Rust targets with `rustup`; install {target}");
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    Ok(rust_target_list_contains(&stdout, target))
+}
+
+fn rust_target_list_contains(installed_targets: &str, target: &str) -> bool {
+    installed_targets.lines().any(|line| line.trim() == target)
 }
 
 fn patch_emsdk_windows(emsdk_dir: &Path) -> Result<()> {

--- a/xtask/src/toolchains/env.rs
+++ b/xtask/src/toolchains/env.rs
@@ -46,6 +46,16 @@ pub(crate) fn apply_toolchains<'a>(
         path_additions.push(uv_dir.display().to_string());
     }
 
+    let bun_dir = ctx.bun_toolchain_dir();
+    if bun_dir.exists() {
+        path_additions.push(bun_dir.display().to_string());
+    }
+
+    let cmake_bin_dir = ctx.cmake_bin_dir()?;
+    if cmake_bin_dir.exists() {
+        path_additions.push(cmake_bin_dir.display().to_string());
+    }
+
     if let Some(deployment_target) = macos_deployment_target() {
         output::detail("macOS deployment target", deployment_target);
         command = command.env("MACOSX_DEPLOYMENT_TARGET", deployment_target);

--- a/xtask/src/toolchains/env.rs
+++ b/xtask/src/toolchains/env.rs
@@ -3,7 +3,6 @@
 use crate::cli::Backend;
 use crate::output;
 use crate::toolchains::cuda::{cuda_architectures, setup_cuda};
-use crate::toolchains::ninja::setup_ninja;
 use crate::toolchains::vulkan::{setup_vulkan, VULKAN_VERSION};
 use crate::utils::BuildContext;
 use anyhow::Result;
@@ -29,10 +28,10 @@ pub(crate) fn apply_toolchains<'a>(
     mut command: Cmd<'a>,
     backend: Option<&Backend>,
 ) -> Result<Cmd<'a>> {
-    let ninja_dir = setup_ninja(sh, ctx)?;
     let mut path_additions = Vec::new();
 
-    if let Some(ninja_dir) = &ninja_dir {
+    let ninja_dir = ctx.ninja_toolchain_dir();
+    if ctx.ninja_exe().exists() {
         path_additions.push(ninja_dir.display().to_string());
         command = command.env("CMAKE_GENERATOR", "Ninja");
     }

--- a/xtask/src/toolchains/mod.rs
+++ b/xtask/src/toolchains/mod.rs
@@ -1,8 +1,11 @@
 //! Host toolchain discovery and bootstrapping.
 
+pub(crate) mod bun;
+pub(crate) mod cmake;
 pub(crate) mod cuda;
 pub(crate) mod emsdk;
 pub(crate) mod env;
 pub(crate) mod ninja;
 pub(crate) mod python;
+pub(crate) mod source;
 pub(crate) mod vulkan;

--- a/xtask/src/toolchains/ninja.rs
+++ b/xtask/src/toolchains/ninja.rs
@@ -3,40 +3,64 @@
 use crate::output;
 use crate::utils::BuildContext;
 use anyhow::Result;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use xshell::{cmd, Shell};
 
 const NINJA_VERSION: &str = "1.13.2";
 
 /// Ensures Ninja is available when the host platform needs a hermetic copy.
 pub(crate) fn setup_ninja(sh: &Shell, ctx: &BuildContext) -> Result<Option<PathBuf>> {
-    if cfg!(windows) {
-        let ninja_dir = ctx.toolchain_dir().join("ninja");
-        let ninja_exe = ninja_dir.join("ninja.exe");
+    let ninja_dir = ctx.toolchain_dir().join("ninja");
+    let ninja_exe = ctx.ninja_exe();
 
-        if !ninja_exe.exists() {
-            output::phase("Ninja build tool");
-            output::path("Install directory", &ninja_dir);
-            sh.create_dir(&ninja_dir)?;
+    if !ninja_exe.exists() {
+        output::phase("Ninja build tool");
+        output::path("Install directory", &ninja_dir);
+        sh.create_dir(&ninja_dir)?;
 
-            let url = format!(
-                "https://github.com/ninja-build/ninja/releases/download/v{}/ninja-win.zip",
-                NINJA_VERSION
-            );
-            let zip_path = ninja_dir.join("ninja-win.zip");
+        let filename = ninja_filename()?;
+        let url = format!(
+            "https://github.com/ninja-build/ninja/releases/download/v{NINJA_VERSION}/{filename}"
+        );
+        let zip_path = ninja_dir.join(filename);
 
-            output::run_command("Downloading Ninja", cmd!(sh, "curl -L -o {zip_path} {url}"))?;
-            output::run_command(
-                "Extracting Ninja",
-                cmd!(sh, "tar -xf {zip_path} -C {ninja_dir}"),
-            )?;
-            sh.remove_path(zip_path)?;
-        } else {
-            output::success(format!("Using Ninja at {}", ninja_exe.display()));
-        }
-        Ok(Some(ninja_dir))
+        output::run_command("Downloading Ninja", cmd!(sh, "curl -L -o {zip_path} {url}"))?;
+        output::run_command(
+            "Extracting Ninja",
+            cmd!(sh, "tar -xf {zip_path} -C {ninja_dir}"),
+        )?;
+        make_unix_executable(&ninja_exe)?;
+        sh.remove_path(zip_path)?;
     } else {
-        output::detail("Ninja", "using host build tools");
-        Ok(None)
+        output::success(format!("Using Ninja at {}", ninja_exe.display()));
     }
+
+    Ok(Some(ninja_dir))
+}
+
+fn ninja_filename() -> Result<&'static str> {
+    if cfg!(windows) {
+        Ok("ninja-win.zip")
+    } else if cfg!(target_os = "macos") {
+        Ok("ninja-mac.zip")
+    } else if cfg!(target_os = "linux") {
+        Ok("ninja-linux.zip")
+    } else {
+        anyhow::bail!("managed Ninja is not available for this host platform")
+    }
+}
+
+#[cfg(unix)]
+fn make_unix_executable(path: &Path) -> Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+
+    let mut permissions = std::fs::metadata(path)?.permissions();
+    permissions.set_mode(0o755);
+    std::fs::set_permissions(path, permissions)?;
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn make_unix_executable(_path: &Path) -> Result<()> {
+    Ok(())
 }

--- a/xtask/src/toolchains/ninja.rs
+++ b/xtask/src/toolchains/ninja.rs
@@ -2,7 +2,7 @@
 
 use crate::output;
 use crate::utils::BuildContext;
-use anyhow::Result;
+use anyhow::{Context, Result};
 use std::path::{Path, PathBuf};
 use xshell::{cmd, Shell};
 
@@ -10,7 +10,7 @@ const NINJA_VERSION: &str = "1.13.2";
 
 /// Ensures Ninja is available when the host platform needs a hermetic copy.
 pub(crate) fn setup_ninja(sh: &Shell, ctx: &BuildContext) -> Result<Option<PathBuf>> {
-    let ninja_dir = ctx.toolchain_dir().join("ninja");
+    let ninja_dir = ctx.ninja_toolchain_dir();
     let ninja_exe = ctx.ninja_exe();
 
     if !ninja_exe.exists() {
@@ -24,11 +24,27 @@ pub(crate) fn setup_ninja(sh: &Shell, ctx: &BuildContext) -> Result<Option<PathB
         );
         let zip_path = ninja_dir.join(filename);
 
-        output::run_command("Downloading Ninja", cmd!(sh, "curl -L -o {zip_path} {url}"))?;
         output::run_command(
-            "Extracting Ninja",
-            cmd!(sh, "tar -xf {zip_path} -C {ninja_dir}"),
+            "Downloading Ninja",
+            cmd!(sh, "curl -f -L -o {zip_path} {url}"),
         )?;
+        if cfg!(windows) {
+            output::run_command(
+                "Extracting Ninja",
+                cmd!(sh, "tar -xf {zip_path} -C {ninja_dir}"),
+            )?;
+        } else {
+            output::run_command(
+                "Extracting Ninja",
+                cmd!(sh, "unzip -oq {zip_path} -d {ninja_dir}"),
+            )?;
+        }
+        if !ninja_exe.exists() {
+            anyhow::bail!(
+                "Ninja archive did not contain expected executable {}",
+                ninja_exe.display()
+            );
+        }
         make_unix_executable(&ninja_exe)?;
         sh.remove_path(zip_path)?;
     } else {
@@ -54,10 +70,12 @@ fn ninja_filename() -> Result<&'static str> {
 fn make_unix_executable(path: &Path) -> Result<()> {
     use std::os::unix::fs::PermissionsExt;
 
-    let mut permissions = std::fs::metadata(path)?.permissions();
+    let mut permissions = std::fs::metadata(path)
+        .with_context(|| format!("failed to inspect {}", path.display()))?
+        .permissions();
     permissions.set_mode(0o755);
-    std::fs::set_permissions(path, permissions)?;
-    Ok(())
+    std::fs::set_permissions(path, permissions)
+        .with_context(|| format!("failed to mark {} executable", path.display()))
 }
 
 #[cfg(not(unix))]

--- a/xtask/src/toolchains/source.rs
+++ b/xtask/src/toolchains/source.rs
@@ -1,0 +1,26 @@
+//! Source dependency bootstrapping.
+
+use crate::output;
+use crate::utils::BuildContext;
+use anyhow::Result;
+use xshell::{cmd, Shell};
+
+/// Ensures the vendored llama.cpp submodule is checked out.
+pub(crate) fn ensure_llama_cpp_submodule(sh: &Shell, ctx: &BuildContext) -> Result<()> {
+    let llama_dir = ctx.llama_cpp_dir();
+    if llama_dir.join("CMakeLists.txt").exists() {
+        output::success(format!("Using llama.cpp at {}", llama_dir.display()));
+        return Ok(());
+    }
+
+    output::phase("Source dependencies");
+    output::path("llama.cpp", &llama_dir);
+    let _root_dir = sh.push_dir(ctx.workspace_root());
+    output::run_command(
+        "Initializing llama.cpp submodule",
+        cmd!(
+            sh,
+            "git submodule update --init --recursive crates/sys/llama.cpp"
+        ),
+    )
+}

--- a/xtask/src/toolchains/vulkan.rs
+++ b/xtask/src/toolchains/vulkan.rs
@@ -64,7 +64,7 @@ pub(crate) fn setup_vulkan(sh: &Shell, ctx: &BuildContext) -> Result<PathBuf> {
         } else if cfg!(target_os = "macos") {
             output::run_command(
                 "Extracting Vulkan SDK",
-                cmd!(sh, "unzip -q {archive_path} -d {vulkan_dir}"),
+                cmd!(sh, "unzip -oq {archive_path} -d {vulkan_dir}"),
             )?;
         } else {
             output::run_command(

--- a/xtask/src/utils.rs
+++ b/xtask/src/utils.rs
@@ -350,6 +350,29 @@ impl BuildContext {
             .join(if cfg!(windows) { "uv.exe" } else { "uv" })
     }
 
+    pub(crate) fn bun_toolchain_dir(&self) -> PathBuf {
+        self.toolchain_dir().join("bun")
+    }
+
+    pub(crate) fn bun_exe(&self) -> PathBuf {
+        self.bun_toolchain_dir()
+            .join(if cfg!(windows) { "bun.exe" } else { "bun" })
+    }
+
+    pub(crate) fn cmake_toolchain_dir(&self) -> PathBuf {
+        self.toolchain_dir().join("cmake")
+    }
+
+    pub(crate) fn cmake_bin_dir(&self) -> Result<PathBuf> {
+        crate::toolchains::cmake::cmake_bin_dir(&self.cmake_toolchain_dir())
+    }
+
+    pub(crate) fn cmake_exe(&self) -> Result<PathBuf> {
+        Ok(self
+            .cmake_bin_dir()?
+            .join(if cfg!(windows) { "cmake.exe" } else { "cmake" }))
+    }
+
     pub(crate) fn ninja_toolchain_dir(&self) -> PathBuf {
         self.toolchain_dir().join("ninja")
     }


### PR DESCRIPTION
In this PR, I updated the xtask setup for sipp initialization. Basically, we assume that nothing has been installed in a new environment and manage everything from the .build files.

## Summary
  - Add managed `.build/toolchain` setup for Bun, CMake, Ninja, Emscripten, and the Rust wasm target (i.e. wasm32-unknown-emscripten target).
  - Pin Bun downloads to a fixed release and validate cached Bun versions (right now it is 1.3.14)
  - Initialize the llama.cpp submodule during setup/build flows that require it (if the git clone did not download everything recursively via submodule)
  - Route JS, WASM, and dev server commands through managed Bun instead of host `bun`
  - Update setup launchers/env scripts to expose managed toolchain paths