### PR TITLE
Fix runtime asset resolution and validation for WASM/pthread configurations

### DIFF
--- a/lib/web/src/engine/runtime-assets.ts
+++ b/lib/web/src/engine/runtime-assets.ts
@@ -20,6 +20,10 @@ interface BundledRuntimeAsset {
   readonly backendOverride: RuntimeBackendOverride | null;
 }
 
+interface RuntimeUrlResolutionOptions {
+  readonly bundledRuntimeUrls?: () => RuntimeUrls;
+}
+
 const DEFAULT_BUNDLED_RUNTIME: BundledRuntimeAsset = {
   artifactName: 'sipp-wasm-pthread',
   backendOverride: null,
@@ -220,7 +224,8 @@ export function resolveRuntimeUrls(
     | 'pthreadWasmUrl'
     | 'trustedOrigins'
     | 'wasmThreading'
-  >
+  >,
+  options: RuntimeUrlResolutionOptions = {}
 ): RuntimeUrls {
   const configuredModuleUrl = normalizeOptionalString(config.moduleUrl);
   const configuredWasmUrl = normalizeOptionalString(config.wasmUrl);
@@ -257,10 +262,10 @@ export function resolveRuntimeUrls(
       wasmUrl: parseConfiguredUrl(configuredPthreadWasmUrl!, 'pthreadWasmUrl'),
     };
   } else {
-    const defaults = bundledRuntimeUrls();
+    const defaults = (options.bundledRuntimeUrls ?? bundledRuntimeUrls)();
     resolved = {
-      moduleUrl: new URL(defaults.moduleUrl),
-      wasmUrl: new URL(defaults.wasmUrl),
+      moduleUrl: parseConfiguredUrl(defaults.moduleUrl, 'moduleUrl'),
+      wasmUrl: parseConfiguredUrl(defaults.wasmUrl, 'wasmUrl'),
     };
   }
 

--- a/lib/web/tests/engine/runtime-assets.test.ts
+++ b/lib/web/tests/engine/runtime-assets.test.ts
@@ -56,6 +56,29 @@ test('resolveRuntimeUrls uses bundled runtime assets when no overrides are provi
   });
 });
 
+test('resolveRuntimeUrls accepts root-relative bundled runtime assets', () => {
+  withWasmPthreadSupport(() => {
+    const resolved = withLocation('https://app.test/_next/static/chunks/model-service-entry.js', () =>
+      resolveRuntimeUrls(
+        {},
+        {
+          bundledRuntimeUrls: () => ({
+            moduleUrl: '/_next/static/media/sipp-wasm-pthread.41xk03exto5xs.js',
+            wasmUrl: '/_next/static/media/sipp-wasm-pthread.0vprqr1jq_rfe.wasm',
+            threading: 'pthread',
+          }),
+        }
+      )
+    );
+
+    assert.deepEqual(resolved, {
+      moduleUrl: 'https://app.test/_next/static/media/sipp-wasm-pthread.41xk03exto5xs.js',
+      wasmUrl: 'https://app.test/_next/static/media/sipp-wasm-pthread.0vprqr1jq_rfe.wasm',
+      threading: 'pthread',
+    });
+  });
+});
+
 test('getDefaultRuntimeUrls maps Vite optimized deps back to package wasm assets', () => {
   withWasmPthreadSupport(() => {
     assert.deepEqual(


### PR DESCRIPTION
**Issue:** 
The resolution of bundled WASM module URLs failed within a Next.js configuration. 

**Fix:**
 Now the bundled default runtime URLs go through the existing base-aware parser before trusted-origin validation.

**Validation:**
bun test tests/engine/runtime-assets.test.ts from lib/web: 22 passed
cargo xtask test unit suite browser --plain --verbose: 188 passed