### PR TITLE
Fix linux and cuda builds

### DIFF
--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -91,6 +91,7 @@ jobs:
     env:
       SIPP_CUDA_ARCHITECTURES: ${{ inputs.cuda-architectures }}
       SIPP_PYTHON_WHEEL_COMPATIBILITY: ${{ matrix.abi }}
+      SIPP_USE_SYSTEM_VULKAN: ${{ matrix.system_vulkan }}
       CARGO_PROFILE_RELEASE_LTO: ${{ inputs.release-lto }}
       CARGO_PROFILE_RELEASE_CODEGEN_UNITS: ${{ inputs.release-codegen-units }}
     strategy:
@@ -104,6 +105,7 @@ jobs:
             cuda_repo: rhel8
             backends: cpu,vulkan,cuda
             cuda: true
+            system_vulkan: "1"
           - id: windows-x64
             os: windows-2022
             abi: host
@@ -194,7 +196,12 @@ jobs:
             libstdc++-static \
             vulkan-loader-devel \
             vulkan-headers
+          dnf install -y glslc || dnf install -y shaderc
           dnf clean all
+          if ! command -v glslc >/dev/null 2>&1; then
+            echo "::error::Linux Vulkan builds require a system glslc that runs on manylinux_2_28."
+            exit 1
+          fi
           cxx="${CXX:-c++}"
           stdcpp_archive="$("$cxx" -print-file-name=libstdc++.a)"
           if [ ! -f "$stdcpp_archive" ]; then
@@ -212,6 +219,7 @@ jobs:
           } >> "$GITHUB_ENV"
           echo "/usr/local/cuda-${CUDA_VERSION}/bin" >> "$GITHUB_PATH"
           "/usr/local/cuda-${CUDA_VERSION}/bin/nvcc" --version
+          glslc --version
 
       - name: Install Windows CUDA 13.0 compiler and development libraries
         if: ${{ runner.os == 'Windows' && matrix.cuda && (inputs.package == 'all' || inputs.package == 'node-npm' || inputs.package == 'python') }}
@@ -263,6 +271,9 @@ jobs:
         run: |
           echo "OS package set: ${{ matrix.id }}"
           echo "Native backends: ${{ matrix.backends }}"
+          if [ "${{ matrix.cuda }}" = "true" ]; then
+            echo "CUDA architectures: $SIPP_CUDA_ARCHITECTURES"
+          fi
 
       - name: Build Node native artifacts
         if: ${{ inputs.package == 'all' || inputs.package == 'node-npm' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,11 @@ on:
           - non-cuda
           - macos
           - all
+      cuda_architectures:
+        description: CUDA arch list for release wheels; 86-real keeps the first PyPI CUDA upload small
+        required: true
+        default: "86-real"
+        type: string
 
 permissions:
   actions: read
@@ -486,6 +491,7 @@ jobs:
       python-version: ${{ needs.preflight.outputs.version }}
       enforce: true
       pypi-wheel-scope: ${{ inputs.pypi_wheel_scope }}
+      cuda-architectures: ${{ inputs.cuda_architectures }}
 
   node-npm:
     name: Assemble Node npm packages

--- a/xtask/src/tests/toolchains/env_tests.rs
+++ b/xtask/src/tests/toolchains/env_tests.rs
@@ -3,7 +3,8 @@
 //! Covers deterministic platform path-separator selection and native command
 //! environment setup without downloading external toolchains.
 
-use crate::test_support::TempDir;
+use crate::cli::Backend;
+use crate::test_support::{EnvGuard, TempDir};
 use crate::utils::BuildContext;
 use xshell::cmd;
 
@@ -38,4 +39,16 @@ fn native_toolchain_env_does_not_install_missing_ninja() {
     let _command = apply_toolchains(&sh, &ctx, cmd!(sh, "true"), None).unwrap();
 
     assert!(!ctx.ninja_toolchain_dir().exists());
+}
+
+#[test]
+fn system_vulkan_env_skips_managed_sdk_install() {
+    let temp = TempDir::new("env-system-vulkan");
+    let ctx = BuildContext::from_workspace_root_for_test(temp.path());
+    let sh = xshell::Shell::new().unwrap();
+    let _env = EnvGuard::new(&[("SIPP_USE_SYSTEM_VULKAN", Some("1"))]);
+
+    let _command = apply_toolchains(&sh, &ctx, cmd!(sh, "true"), Some(&Backend::Vulkan)).unwrap();
+
+    assert!(!ctx.vulkan_dir().exists());
 }

--- a/xtask/src/toolchains/env.rs
+++ b/xtask/src/toolchains/env.rs
@@ -63,37 +63,41 @@ pub(crate) fn apply_toolchains<'a>(
     match backend {
         Some(Backend::Vulkan) => {
             output::detail("Toolchain", "Vulkan");
-            let vulkan_dir = setup_vulkan(sh, ctx)?;
-            let bin_path = if cfg!(windows) {
-                vulkan_dir.join("Bin")
-            } else if cfg!(target_os = "macos") {
-                vulkan_dir.join("macOS").join("bin")
+            if use_system_vulkan() {
+                output::detail("Vulkan SDK", "system");
             } else {
-                vulkan_dir.join(VULKAN_VERSION).join("x86_64").join("bin")
-            };
-            path_additions.push(bin_path.display().to_string());
+                let vulkan_dir = setup_vulkan(sh, ctx)?;
+                let bin_path = if cfg!(windows) {
+                    vulkan_dir.join("Bin")
+                } else if cfg!(target_os = "macos") {
+                    vulkan_dir.join("macOS").join("bin")
+                } else {
+                    vulkan_dir.join(VULKAN_VERSION).join("x86_64").join("bin")
+                };
+                path_additions.push(bin_path.display().to_string());
 
-            let vulkan_sdk_path = if cfg!(windows) {
-                vulkan_dir.to_path_buf()
-            } else if cfg!(target_os = "macos") {
-                vulkan_dir.join("macOS")
-            } else {
-                vulkan_dir.join(VULKAN_VERSION).join("x86_64")
-            };
-            command = command.env("VULKAN_SDK", &vulkan_sdk_path);
+                let vulkan_sdk_path = if cfg!(windows) {
+                    vulkan_dir.to_path_buf()
+                } else if cfg!(target_os = "macos") {
+                    vulkan_dir.join("macOS")
+                } else {
+                    vulkan_dir.join(VULKAN_VERSION).join("x86_64")
+                };
+                command = command.env("VULKAN_SDK", &vulkan_sdk_path);
 
-            let current_cmake_prefix = std_env::var("CMAKE_PREFIX_PATH").unwrap_or_default();
-            let separator = path_separator();
-            let new_cmake_prefix = if current_cmake_prefix.is_empty() {
-                vulkan_sdk_path.display().to_string()
-            } else {
-                format!(
-                    "{}{separator}{}",
-                    vulkan_sdk_path.display(),
-                    current_cmake_prefix
-                )
-            };
-            command = command.env("CMAKE_PREFIX_PATH", new_cmake_prefix);
+                let current_cmake_prefix = std_env::var("CMAKE_PREFIX_PATH").unwrap_or_default();
+                let separator = path_separator();
+                let new_cmake_prefix = if current_cmake_prefix.is_empty() {
+                    vulkan_sdk_path.display().to_string()
+                } else {
+                    format!(
+                        "{}{separator}{}",
+                        vulkan_sdk_path.display(),
+                        current_cmake_prefix
+                    )
+                };
+                command = command.env("CMAKE_PREFIX_PATH", new_cmake_prefix);
+            }
         }
         Some(Backend::Cuda) => {
             output::detail("Toolchain", "CUDA");
@@ -136,6 +140,16 @@ fn path_separator() -> &'static str {
     } else {
         ":"
     }
+}
+
+fn use_system_vulkan() -> bool {
+    let Some(value) = std_env::var_os("SIPP_USE_SYSTEM_VULKAN") else {
+        return false;
+    };
+    matches!(
+        value.to_string_lossy().trim().to_ascii_lowercase().as_str(),
+        "1" | "true" | "yes" | "on"
+    )
 }
 
 fn macos_deployment_target() -> Option<&'static str> {


### PR DESCRIPTION
This PR fixed an issue introduced in #66 where the managed Vulkan SDK was used for manylinux build. This PR changed Linux x64 native CI to use system Vulkan tooling inside the manylinux container instead of xtask’s managed Vulkan SDK.

We also first release an 86-real-arch Python CUDA wheel and then request a size-limit increase. 