### PR TITLE
Fix the vulkan build on linux

### DIFF
--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -77,6 +77,8 @@ env:
   CUDA_PACKAGE_SUFFIX: "13-0"
   CUDA_WINDOWS_INSTALLER_URL: https://developer.download.nvidia.com/compute/cuda/13.0.3/local_installers/cuda_13.0.3_windows.exe
   NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  SHADERC_REF: "d5f08ae5c5a9a45165578445cbd0f9adf0223448"
+  SHADERC_VERSION: "v2026.2"
   SIPP_MAX_GLIBC: "2.28"
   SIPP_MAX_WHEEL_MB: "100"
 
@@ -91,7 +93,6 @@ jobs:
     env:
       SIPP_CUDA_ARCHITECTURES: ${{ inputs.cuda-architectures }}
       SIPP_PYTHON_WHEEL_COMPATIBILITY: ${{ matrix.abi }}
-      SIPP_USE_SYSTEM_VULKAN: ${{ matrix.system_vulkan }}
       CARGO_PROFILE_RELEASE_LTO: ${{ inputs.release-lto }}
       CARGO_PROFILE_RELEASE_CODEGEN_UNITS: ${{ inputs.release-codegen-units }}
     strategy:
@@ -105,7 +106,6 @@ jobs:
             cuda_repo: rhel8
             backends: cpu,vulkan,cuda
             cuda: true
-            system_vulkan: "1"
           - id: windows-x64
             os: windows-2022
             abi: host
@@ -177,10 +177,11 @@ jobs:
         with:
           path: |
             .build/toolchain/uv
+            .build/toolchain/glslc
             .build/uv-cache
-          key: sipp-uv-toolchain-build-native-v2-${{ runner.os }}-${{ runner.arch }}-${{ matrix.id }}-${{ matrix.os }}-${{ matrix.abi }}-${{ hashFiles('xtask/src/toolchains/*.rs') }}
+          key: sipp-native-toolchains-build-native-v2-${{ runner.os }}-${{ runner.arch }}-${{ matrix.id }}-${{ matrix.os }}-${{ matrix.abi }}-${{ env.SHADERC_REF }}-${{ hashFiles('xtask/src/toolchains/*.rs') }}
           restore-keys: |
-            sipp-uv-toolchain-build-native-v2-${{ runner.os }}-${{ runner.arch }}-${{ matrix.id }}-${{ matrix.os }}-${{ matrix.abi }}-
+            sipp-native-toolchains-build-native-v2-${{ runner.os }}-${{ runner.arch }}-${{ matrix.id }}-${{ matrix.os }}-${{ matrix.abi }}-
 
       - name: Install Linux CUDA 13.0 and Vulkan development libraries
         if: ${{ runner.os == 'Linux' && matrix.cuda && (inputs.package == 'all' || inputs.package == 'node-npm' || inputs.package == 'python') }}
@@ -193,15 +194,12 @@ jobs:
           dnf install -y \
             "cuda-compiler-${CUDA_PACKAGE_SUFFIX}" \
             "cuda-libraries-devel-${CUDA_PACKAGE_SUFFIX}" \
+            git \
+            python3 \
             libstdc++-static \
             vulkan-loader-devel \
             vulkan-headers
-          dnf install -y glslc || dnf install -y shaderc
           dnf clean all
-          if ! command -v glslc >/dev/null 2>&1; then
-            echo "::error::Linux Vulkan builds require a system glslc that runs on manylinux_2_28."
-            exit 1
-          fi
           cxx="${CXX:-c++}"
           stdcpp_archive="$("$cxx" -print-file-name=libstdc++.a)"
           if [ ! -f "$stdcpp_archive" ]; then
@@ -219,7 +217,51 @@ jobs:
           } >> "$GITHUB_ENV"
           echo "/usr/local/cuda-${CUDA_VERSION}/bin" >> "$GITHUB_PATH"
           "/usr/local/cuda-${CUDA_VERSION}/bin/nvcc" --version
-          glslc --version
+
+      - name: Build Linux glslc for manylinux
+        if: ${{ runner.os == 'Linux' && matrix.cuda && (inputs.package == 'all' || inputs.package == 'node-npm' || inputs.package == 'python') }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          glslc_bin="$PWD/.build/toolchain/glslc/${SHADERC_VERSION}/bin/glslc"
+          if [ ! -x "$glslc_bin" ]; then
+            command -v cmake
+            command -v python3
+            command -v git
+            cmake --version
+            python3 --version
+            git --version
+            generator_args=()
+            if command -v ninja >/dev/null 2>&1; then
+              ninja --version
+              generator_args=(-GNinja)
+            else
+              echo "::warning::ninja is not on PATH; using CMake's default generator for glslc."
+            fi
+            shaderc_src="$RUNNER_TEMP/shaderc-src"
+            shaderc_build="$RUNNER_TEMP/shaderc-build"
+            rm -rf "$shaderc_src" "$shaderc_build"
+            git init "$shaderc_src"
+            git -C "$shaderc_src" remote add origin https://github.com/google/shaderc.git
+            git -C "$shaderc_src" fetch --depth 1 origin "$SHADERC_REF"
+            git -C "$shaderc_src" checkout --detach FETCH_HEAD
+            echo "Shaderc commit: $(git -C "$shaderc_src" rev-parse HEAD)"
+            "$shaderc_src/utils/git-sync-deps"
+            cmake -S "$shaderc_src" -B "$shaderc_build" "${generator_args[@]}" \
+              -DCMAKE_BUILD_TYPE=Release \
+              -DSHADERC_SKIP_TESTS=ON \
+              -DSHADERC_SKIP_EXAMPLES=ON \
+              -DSHADERC_SKIP_EXECUTABLES=OFF
+            cmake --build "$shaderc_build" --target glslc_exe --parallel 1
+            mkdir -p "$(dirname "$glslc_bin")"
+            cp "$shaderc_build/glslc/glslc" "$glslc_bin"
+            chmod +x "$glslc_bin"
+            strip "$glslc_bin" || true
+          else
+            echo "Using cached glslc at $glslc_bin"
+          fi
+          "$glslc_bin" --version
+          echo "SIPP_GLSLC=$glslc_bin" >> "$GITHUB_ENV"
 
       - name: Install Windows CUDA 13.0 compiler and development libraries
         if: ${{ runner.os == 'Windows' && matrix.cuda && (inputs.package == 'all' || inputs.package == 'node-npm' || inputs.package == 'python') }}
@@ -273,6 +315,9 @@ jobs:
           echo "Native backends: ${{ matrix.backends }}"
           if [ "${{ matrix.cuda }}" = "true" ]; then
             echo "CUDA architectures: $SIPP_CUDA_ARCHITECTURES"
+          fi
+          if [ -n "${SIPP_GLSLC:-}" ]; then
+            echo "glslc override: $SIPP_GLSLC"
           fi
 
       - name: Build Node native artifacts

--- a/crates/sys/build_support/cmake.rs
+++ b/crates/sys/build_support/cmake.rs
@@ -72,13 +72,15 @@ pub(crate) fn build_native(context: &BuildContext) -> PathBuf {
 }
 
 fn apply_vulkan_cmake_overrides(context: &BuildContext, config: &mut Config) {
-    let Some(vulkan_sdk) = &context.env_vars.vulkan_sdk else {
-        return;
-    };
+    if let Some(vulkan_sdk) = &context.env_vars.vulkan_sdk {
+        config.define("Vulkan_ROOT", vulkan_sdk.as_os_str());
+        if let Some(loader) = vulkan_loader_library(vulkan_sdk) {
+            config.define("Vulkan_LIBRARY", loader.as_os_str());
+        }
+    }
 
-    config.define("Vulkan_ROOT", vulkan_sdk.as_os_str());
-    if let Some(loader) = vulkan_loader_library(vulkan_sdk) {
-        config.define("Vulkan_LIBRARY", loader.as_os_str());
+    if let Some(glslc) = &context.env_vars.glslc {
+        config.define("Vulkan_GLSLC_EXECUTABLE", glslc.as_os_str());
     }
 }
 

--- a/crates/sys/build_support/context.rs
+++ b/crates/sys/build_support/context.rs
@@ -64,6 +64,7 @@ impl BuildContext {
         println!("cargo:rerun-if-env-changed=CUDA_PATH");
         println!("cargo:rerun-if-env-changed=CUDA_HOME");
         println!("cargo:rerun-if-env-changed=VULKAN_SDK");
+        println!("cargo:rerun-if-env-changed=SIPP_GLSLC");
         println!("cargo:rerun-if-env-changed=EMSDK");
         println!("cargo:rerun-if-env-changed=SIPP_SYS_CMAKE_OUT_DIR");
         println!("cargo:rerun-if-env-changed=SIPP_CUDA_ARCHITECTURES");
@@ -129,6 +130,7 @@ pub(crate) struct BuildEnv {
     pub(crate) cuda_path: Option<PathBuf>,
     pub(crate) cuda_architectures: Option<String>,
     pub(crate) vulkan_sdk: Option<PathBuf>,
+    pub(crate) glslc: Option<PathBuf>,
     pub(crate) cmake_out_dir: Option<PathBuf>,
     pub(crate) static_cxx_runtime_lib_dir: Option<PathBuf>,
 }
@@ -144,6 +146,7 @@ impl BuildEnv {
                 .map(|value| value.trim().to_owned())
                 .filter(|value| !value.is_empty()),
             vulkan_sdk: env::var_os("VULKAN_SDK").map(PathBuf::from),
+            glslc: env_path("SIPP_GLSLC"),
             cmake_out_dir: env::var("SIPP_SYS_CMAKE_OUT_DIR").ok().map(sanitize_path),
             static_cxx_runtime_lib_dir: env_path("SIPP_STATIC_CXX_RUNTIME_LIB_DIR"),
         }

--- a/crates/sys/src/tests/build_support/context_tests.rs
+++ b/crates/sys/src/tests/build_support/context_tests.rs
@@ -26,6 +26,7 @@ const CONTEXT_ENV_VARS: &[(&str, Option<&str>)] = &[
     ("CUDA_HOME", None),
     ("SIPP_CUDA_ARCHITECTURES", None),
     ("VULKAN_SDK", None),
+    ("SIPP_GLSLC", None),
     ("SIPP_SYS_CMAKE_OUT_DIR", None),
     ("SIPP_STATIC_CXX_RUNTIME_LIB_DIR", None),
 ];
@@ -53,6 +54,7 @@ fn context_for(manifest_dir: PathBuf, target: &str, features: FeatureFlags) -> B
             cuda_path: None,
             cuda_architectures: None,
             vulkan_sdk: None,
+            glslc: None,
             cmake_out_dir: None,
             static_cxx_runtime_lib_dir: None,
         },
@@ -122,6 +124,7 @@ fn build_env_prefers_cuda_path_and_sanitizes_cmake_output() {
         ("CUDA_HOME", Some("cuda-home")),
         ("SIPP_CUDA_ARCHITECTURES", Some(" 80;90 ")),
         ("VULKAN_SDK", Some("vulkan-sdk")),
+        ("SIPP_GLSLC", Some(r"\\?\toolchain\glslc")),
         ("SIPP_SYS_CMAKE_OUT_DIR", Some(r"\\?\cmake-out")),
         ("SIPP_STATIC_CXX_RUNTIME_LIB_DIR", Some(r"\\?\stdcpp-lib")),
     ]);
@@ -130,6 +133,7 @@ fn build_env_prefers_cuda_path_and_sanitizes_cmake_output() {
     assert_eq!(env.cuda_path, Some(PathBuf::from("cuda-path")));
     assert_eq!(env.cuda_architectures, Some("80;90".to_owned()));
     assert_eq!(env.vulkan_sdk, Some(PathBuf::from("vulkan-sdk")));
+    assert_eq!(env.glslc, Some(PathBuf::from(r"toolchain\glslc")));
     assert_eq!(env.cmake_out_dir, Some(PathBuf::from("cmake-out")));
     assert_eq!(
         env.static_cxx_runtime_lib_dir,
@@ -144,11 +148,13 @@ fn build_env_treats_blank_static_cxx_runtime_lib_dir_as_unset() {
         ("CUDA_HOME", None),
         ("SIPP_CUDA_ARCHITECTURES", None),
         ("VULKAN_SDK", None),
+        ("SIPP_GLSLC", Some("   ")),
         ("SIPP_SYS_CMAKE_OUT_DIR", None),
         ("SIPP_STATIC_CXX_RUNTIME_LIB_DIR", Some("   ")),
     ]);
 
     let env = BuildEnv::from_env();
+    assert_eq!(env.glslc, None);
     assert_eq!(env.static_cxx_runtime_lib_dir, None);
 }
 
@@ -159,6 +165,7 @@ fn build_env_falls_back_to_cuda_home() {
         ("CUDA_HOME", Some("cuda-home")),
         ("SIPP_CUDA_ARCHITECTURES", None),
         ("VULKAN_SDK", None),
+        ("SIPP_GLSLC", None),
         ("SIPP_SYS_CMAKE_OUT_DIR", None),
         ("SIPP_STATIC_CXX_RUNTIME_LIB_DIR", None),
     ]);
@@ -167,6 +174,7 @@ fn build_env_falls_back_to_cuda_home() {
     assert_eq!(env.cuda_path, Some(PathBuf::from("cuda-home")));
     assert_eq!(env.cuda_architectures, None);
     assert_eq!(env.vulkan_sdk, None);
+    assert_eq!(env.glslc, None);
     assert_eq!(env.cmake_out_dir, None);
     assert_eq!(env.static_cxx_runtime_lib_dir, None);
 }
@@ -178,6 +186,7 @@ fn build_env_treats_blank_cuda_architectures_as_unset() {
         ("CUDA_HOME", None),
         ("SIPP_CUDA_ARCHITECTURES", Some("   ")),
         ("VULKAN_SDK", None),
+        ("SIPP_GLSLC", None),
         ("SIPP_SYS_CMAKE_OUT_DIR", None),
         ("SIPP_STATIC_CXX_RUNTIME_LIB_DIR", None),
     ]);
@@ -199,6 +208,7 @@ fn build_context_new_reads_manifest_target_features_and_env() {
         ("CARGO_CFG_TARGET_OS", Some("unknown")),
         ("CARGO_FEATURE_VULKAN", Some("1")),
         ("VULKAN_SDK", Some("sdk")),
+        ("SIPP_GLSLC", Some("glslc")),
     ]);
     let _env = EnvGuard::new(&vars);
 
@@ -209,6 +219,7 @@ fn build_context_new_reads_manifest_target_features_and_env() {
     assert_eq!(context.target_kind, TargetKind::Emscripten);
     assert!(context.features.vulkan);
     assert_eq!(context.env_vars.vulkan_sdk, Some(PathBuf::from("sdk")));
+    assert_eq!(context.env_vars.glslc, Some(PathBuf::from("glslc")));
 }
 
 #[test]

--- a/crates/sys/src/tests/build_support/ide_tests.rs
+++ b/crates/sys/src/tests/build_support/ide_tests.rs
@@ -33,6 +33,7 @@ fn test_context(temp: &TempDir) -> BuildContext {
             cuda_path: None,
             cuda_architectures: None,
             vulkan_sdk: None,
+            glslc: None,
             cmake_out_dir: None,
             static_cxx_runtime_lib_dir: None,
         },

--- a/crates/sys/src/tests/build_support/targets_tests.rs
+++ b/crates/sys/src/tests/build_support/targets_tests.rs
@@ -35,6 +35,7 @@ fn target_context_with_static_cxx_lib_dir(
             cuda_path: None,
             cuda_architectures: None,
             vulkan_sdk: None,
+            glslc: None,
             cmake_out_dir: None,
             static_cxx_runtime_lib_dir,
         },

--- a/xtask/src/tests/toolchains/env_tests.rs
+++ b/xtask/src/tests/toolchains/env_tests.rs
@@ -3,8 +3,7 @@
 //! Covers deterministic platform path-separator selection and native command
 //! environment setup without downloading external toolchains.
 
-use crate::cli::Backend;
-use crate::test_support::{EnvGuard, TempDir};
+use crate::test_support::TempDir;
 use crate::utils::BuildContext;
 use xshell::cmd;
 
@@ -39,16 +38,4 @@ fn native_toolchain_env_does_not_install_missing_ninja() {
     let _command = apply_toolchains(&sh, &ctx, cmd!(sh, "true"), None).unwrap();
 
     assert!(!ctx.ninja_toolchain_dir().exists());
-}
-
-#[test]
-fn system_vulkan_env_skips_managed_sdk_install() {
-    let temp = TempDir::new("env-system-vulkan");
-    let ctx = BuildContext::from_workspace_root_for_test(temp.path());
-    let sh = xshell::Shell::new().unwrap();
-    let _env = EnvGuard::new(&[("SIPP_USE_SYSTEM_VULKAN", Some("1"))]);
-
-    let _command = apply_toolchains(&sh, &ctx, cmd!(sh, "true"), Some(&Backend::Vulkan)).unwrap();
-
-    assert!(!ctx.vulkan_dir().exists());
 }

--- a/xtask/src/toolchains/env.rs
+++ b/xtask/src/toolchains/env.rs
@@ -63,41 +63,37 @@ pub(crate) fn apply_toolchains<'a>(
     match backend {
         Some(Backend::Vulkan) => {
             output::detail("Toolchain", "Vulkan");
-            if use_system_vulkan() {
-                output::detail("Vulkan SDK", "system");
+            let vulkan_dir = setup_vulkan(sh, ctx)?;
+            let bin_path = if cfg!(windows) {
+                vulkan_dir.join("Bin")
+            } else if cfg!(target_os = "macos") {
+                vulkan_dir.join("macOS").join("bin")
             } else {
-                let vulkan_dir = setup_vulkan(sh, ctx)?;
-                let bin_path = if cfg!(windows) {
-                    vulkan_dir.join("Bin")
-                } else if cfg!(target_os = "macos") {
-                    vulkan_dir.join("macOS").join("bin")
-                } else {
-                    vulkan_dir.join(VULKAN_VERSION).join("x86_64").join("bin")
-                };
-                path_additions.push(bin_path.display().to_string());
+                vulkan_dir.join(VULKAN_VERSION).join("x86_64").join("bin")
+            };
+            path_additions.push(bin_path.display().to_string());
 
-                let vulkan_sdk_path = if cfg!(windows) {
-                    vulkan_dir.to_path_buf()
-                } else if cfg!(target_os = "macos") {
-                    vulkan_dir.join("macOS")
-                } else {
-                    vulkan_dir.join(VULKAN_VERSION).join("x86_64")
-                };
-                command = command.env("VULKAN_SDK", &vulkan_sdk_path);
+            let vulkan_sdk_path = if cfg!(windows) {
+                vulkan_dir.to_path_buf()
+            } else if cfg!(target_os = "macos") {
+                vulkan_dir.join("macOS")
+            } else {
+                vulkan_dir.join(VULKAN_VERSION).join("x86_64")
+            };
+            command = command.env("VULKAN_SDK", &vulkan_sdk_path);
 
-                let current_cmake_prefix = std_env::var("CMAKE_PREFIX_PATH").unwrap_or_default();
-                let separator = path_separator();
-                let new_cmake_prefix = if current_cmake_prefix.is_empty() {
-                    vulkan_sdk_path.display().to_string()
-                } else {
-                    format!(
-                        "{}{separator}{}",
-                        vulkan_sdk_path.display(),
-                        current_cmake_prefix
-                    )
-                };
-                command = command.env("CMAKE_PREFIX_PATH", new_cmake_prefix);
-            }
+            let current_cmake_prefix = std_env::var("CMAKE_PREFIX_PATH").unwrap_or_default();
+            let separator = path_separator();
+            let new_cmake_prefix = if current_cmake_prefix.is_empty() {
+                vulkan_sdk_path.display().to_string()
+            } else {
+                format!(
+                    "{}{separator}{}",
+                    vulkan_sdk_path.display(),
+                    current_cmake_prefix
+                )
+            };
+            command = command.env("CMAKE_PREFIX_PATH", new_cmake_prefix);
         }
         Some(Backend::Cuda) => {
             output::detail("Toolchain", "CUDA");
@@ -140,16 +136,6 @@ fn path_separator() -> &'static str {
     } else {
         ":"
     }
-}
-
-fn use_system_vulkan() -> bool {
-    let Some(value) = std_env::var_os("SIPP_USE_SYSTEM_VULKAN") else {
-        return false;
-    };
-    matches!(
-        value.to_string_lossy().trim().to_ascii_lowercase().as_str(),
-        "1" | "true" | "yes" | "on"
-    )
 }
 
 fn macos_deployment_target() -> Option<&'static str> {


### PR DESCRIPTION
This PR tried to solve the problem on the Linux Vulkan build. It seemed that our previously successful Linux Vulkan build was created due to a cached version. Now, this PR tried to resolve this using a correct glslc version and rebuilt Vulkan on manyLinux. 

Verfication:
Used podman to run the test inside `quay.io/pypa/manylinux_2_28_x86_64:latest inside:
- Built shaderc at pinned commit d5f08ae5c
- Built the correct executable target: glslc_exe.
- Ran glslc --version successfully.
- Compiled a tiny Vulkan compute shader to SPIR-V successfully.
- Checked versioned symbols: max GLIBC was GLIBC_2.17, max GLIBCXX was GLIBCXX_3.4.21, both
compatible with manylinux_2_28.