### PR TITLE
Partition encoder requests into batches

### DIFF
--- a/crates/sipp/src/runtime/inference_runtime/encoder.rs
+++ b/crates/sipp/src/runtime/inference_runtime/encoder.rs
@@ -15,6 +15,12 @@ use crate::runtime::scheduler::{
 use super::capabilities::RuntimeModelCapabilities;
 use super::InferenceRuntime;
 
+#[derive(Debug, PartialEq, Eq)]
+enum EncoderAdmissionBatch {
+    Ready { end: usize, token_count: i32 },
+    Oversized { requested: i32 },
+}
+
 impl InferenceRuntime {
     pub(crate) fn text_generation_slot_plan(&self) -> Result<SlotExecutionPlan> {
         text_generation_slot_plan(&self.capabilities)
@@ -24,18 +30,56 @@ impl InferenceRuntime {
         embedding_slot_plan(&self.capabilities)
     }
 
-    pub(super) fn fail_admitted_slot(&mut self, slot_index: usize, error: Error) {
+    fn fail_admitted_slot(&mut self, slot_index: usize, error: &Error) {
         if let Some(slot) = self.slot_scheduler.slots.get_mut(slot_index) {
             slot.fail(format!("admission prefill failed: {error}"));
         }
     }
 
-    pub(super) fn run_encoder_admission_batch(&mut self, slot_indices: &[usize]) -> Result<()> {
-        let max_tokens = encoder_batch_token_count(&self.slot_scheduler.slots, slot_indices)?;
+    pub(super) fn fail_admitted_slots(&mut self, slot_indices: &[usize], error: &Error) {
+        for &slot_index in slot_indices {
+            self.fail_admitted_slot(slot_index, error);
+        }
+    }
+
+    pub(super) fn run_encoder_admission_batches(&mut self, slot_indices: &[usize]) -> Result<()> {
+        let mut start = 0;
+        while start < slot_indices.len() {
+            match next_encoder_admission_batch(
+                &self.slot_scheduler.slots,
+                slot_indices,
+                start,
+                self.resolved_limits.n_ubatch,
+            )? {
+                EncoderAdmissionBatch::Ready { end, token_count } => {
+                    let batch_slots = &slot_indices[start..end];
+                    if let Err(error) = self.run_encoder_admission_batch(batch_slots, token_count) {
+                        self.fail_admitted_slots(batch_slots, &error);
+                    }
+                    start = end;
+                }
+                EncoderAdmissionBatch::Oversized { requested } => {
+                    let error = Error::BatchCapacity {
+                        capacity: self.resolved_limits.n_ubatch,
+                        requested,
+                    };
+                    self.fail_admitted_slot(slot_indices[start], &error);
+                    start += 1;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn run_encoder_admission_batch(
+        &mut self,
+        slot_indices: &[usize],
+        token_count: i32,
+    ) -> Result<()> {
         let max_sequences = i32::try_from(slot_indices.len())
             .map_err(|_| Error::InvalidRequest("encoder batch exceeds i32::MAX sequences"))?;
         self.shared_batch_builder
-            .ensure_capacity(max_tokens, max_sequences)?;
+            .ensure_capacity(token_count, max_sequences)?;
         self.shared_batch_builder.reset();
 
         for &slot_index in slot_indices {
@@ -44,7 +88,7 @@ impl InferenceRuntime {
                 .slots
                 .get(slot_index)
                 .ok_or(Error::RuntimeNotReady)?;
-            add_encoder_prompt_to_batch(&mut self.shared_batch_builder, slot, max_tokens)?;
+            add_encoder_prompt_to_batch(&mut self.shared_batch_builder, slot, token_count)?;
         }
 
         let status = self
@@ -82,7 +126,7 @@ impl InferenceRuntime {
                     }
                 });
             if let Err(error) = result {
-                self.fail_admitted_slot(slot_index, error);
+                self.fail_admitted_slot(slot_index, &error);
             }
         }
         Ok(())
@@ -128,31 +172,55 @@ impl InferenceRuntime {
     }
 }
 
-fn encoder_batch_token_count(slots: &[SlotState], slot_indices: &[usize]) -> Result<i32> {
-    let mut total_tokens = 0_usize;
-    for &slot_index in slot_indices {
-        let slot = slots.get(slot_index).ok_or(Error::RuntimeNotReady)?;
-        let request = slot
-            .request()
-            .ok_or(Error::InvalidRequest("admitted slot has no request"))?;
-        if slot.seq_id < 0 {
-            return Err(Error::InvalidRequest(
-                "admitted slot has no sequence id for encoder pass",
-            ));
+fn next_encoder_admission_batch(
+    slots: &[SlotState],
+    slot_indices: &[usize],
+    start: usize,
+    max_tokens: i32,
+) -> Result<EncoderAdmissionBatch> {
+    let mut end = start;
+    let mut batch_tokens = 0;
+
+    for (position, &slot_index) in slot_indices.iter().enumerate().skip(start) {
+        let prompt_tokens = encoder_prompt_token_count(slots, slot_index)?;
+        if prompt_tokens > max_tokens {
+            if position == start {
+                return Ok(EncoderAdmissionBatch::Oversized {
+                    requested: prompt_tokens,
+                });
+            }
+            break;
         }
-        if request.prompt_tokens.is_empty() {
-            return Err(Error::InvalidRequest(
-                "encoder prompt ingest received an empty token slice",
-            ));
+        if prompt_tokens > max_tokens - batch_tokens {
+            break;
         }
-        total_tokens = total_tokens
-            .checked_add(request.prompt_tokens.len())
-            .ok_or(Error::InvalidRequest(
-                "encoder batch token count overflowed",
-            ))?;
+        batch_tokens += prompt_tokens;
+        end = position + 1;
     }
-    i32::try_from(total_tokens)
-        .map_err(|_| Error::InvalidRequest("encoder batch exceeds i32::MAX tokens"))
+
+    Ok(EncoderAdmissionBatch::Ready {
+        end,
+        token_count: batch_tokens,
+    })
+}
+
+fn encoder_prompt_token_count(slots: &[SlotState], slot_index: usize) -> Result<i32> {
+    let slot = slots.get(slot_index).ok_or(Error::RuntimeNotReady)?;
+    let request = slot
+        .request()
+        .ok_or(Error::InvalidRequest("admitted slot has no request"))?;
+    if slot.seq_id < 0 {
+        return Err(Error::InvalidRequest(
+            "admitted slot has no sequence id for encoder pass",
+        ));
+    }
+    if request.prompt_tokens.is_empty() {
+        return Err(Error::InvalidRequest(
+            "encoder prompt ingest received an empty token slice",
+        ));
+    }
+    i32::try_from(request.prompt_tokens.len())
+        .map_err(|_| Error::InvalidRequest("encoder prompt exceeds i32::MAX tokens"))
 }
 
 fn add_encoder_prompt_to_batch(

--- a/crates/sipp/src/runtime/inference_runtime/lifecycle.rs
+++ b/crates/sipp/src/runtime/inference_runtime/lifecycle.rs
@@ -19,6 +19,8 @@ use super::capabilities::RuntimeModelCapabilities;
 use super::environment::{admit_runtime_residency, snapshot_prefix_cache_enabled};
 use super::{fingerprint_path, nonnegative_i32_to_usize, positive_i32_to_usize, InferenceRuntime};
 
+const DEFAULT_ENCODER_BATCH_SIZE: i32 = 2048;
+
 impl InferenceRuntime {
     pub fn load(
         model_path: impl AsRef<std::path::Path>,
@@ -185,6 +187,7 @@ fn apply_model_class_defaults(config: &mut NativeRuntimeConfig, class: ModelClas
             if config.context.embeddings.is_none() {
                 config.context.embeddings = Some(true);
             }
+            apply_encoder_batch_defaults(config);
         }
         ModelClass::EncoderDecoder => {
             if config.context.embeddings == Some(true) {
@@ -201,9 +204,19 @@ fn apply_model_class_defaults(config: &mut NativeRuntimeConfig, class: ModelClas
                         .to_string(),
                 });
             }
+            apply_encoder_batch_defaults(config);
         }
     }
     Ok(())
+}
+
+fn apply_encoder_batch_defaults(config: &mut NativeRuntimeConfig) {
+    if config.context.n_ubatch.is_some() {
+        return;
+    }
+    let n_batch = config.context.n_batch.unwrap_or(DEFAULT_ENCODER_BATCH_SIZE);
+    config.context.n_batch = Some(n_batch);
+    config.context.n_ubatch = Some(n_batch);
 }
 
 fn build_capabilities(

--- a/crates/sipp/src/runtime/inference_runtime/mod.rs
+++ b/crates/sipp/src/runtime/inference_runtime/mod.rs
@@ -179,13 +179,8 @@ impl InferenceRuntime {
             }
         }
         if !encoder_slots.is_empty() {
-            if let Err(error) = self.run_encoder_admission_batch(&encoder_slots) {
-                let message = format!("admission prefill failed: {error}");
-                for &slot_index in &encoder_slots {
-                    if let Some(slot) = self.slot_scheduler.slots.get_mut(slot_index) {
-                        slot.fail(message.clone());
-                    }
-                }
+            if let Err(error) = self.run_encoder_admission_batches(&encoder_slots) {
+                self.fail_admitted_slots(&encoder_slots, &error);
             }
         }
         encoder_slots.clear();

--- a/crates/sipp/src/tests/runtime/inference_runtime/encoder_tests.rs
+++ b/crates/sipp/src/tests/runtime/inference_runtime/encoder_tests.rs
@@ -156,23 +156,104 @@ fn encoder_decoder_rewrite_preserves_source_input_token_count() {
 }
 
 #[test]
-fn encoder_batch_token_count_sums_admitted_prompt_tokens() {
-    let slots = vec![
-        admitted_encoder_slot(0, 7, 0, vec![11, 12, 13]),
-        admitted_encoder_slot(1, 8, 1, vec![21, 22]),
-    ];
+fn encoder_admission_batch_accepts_prompt_at_ubatch_limit() {
+    let slots = vec![admitted_encoder_slot(0, 7, 0, vec![11, 12, 13])];
 
-    let token_count =
-        super::encoder_batch_token_count(&slots, &[0, 1]).expect("encoder batch token count");
+    let batch =
+        super::next_encoder_admission_batch(&slots, &[0], 0, 3).expect("encoder admission batch");
 
-    assert_eq!(token_count, 5);
+    assert_eq!(
+        batch,
+        super::EncoderAdmissionBatch::Ready {
+            end: 1,
+            token_count: 3,
+        }
+    );
 }
 
 #[test]
-fn encoder_batch_token_count_rejects_empty_prompt() {
+fn encoder_admission_batch_rejects_prompt_above_ubatch_limit() {
+    let slots = vec![admitted_encoder_slot(0, 7, 0, vec![11, 12, 13, 14])];
+
+    let batch =
+        super::next_encoder_admission_batch(&slots, &[0], 0, 3).expect("encoder admission batch");
+
+    assert_eq!(
+        batch,
+        super::EncoderAdmissionBatch::Oversized { requested: 4 }
+    );
+}
+
+#[test]
+fn encoder_admission_batches_partition_concurrent_prompts_in_order() {
+    let slots = vec![
+        admitted_encoder_slot(0, 7, 0, vec![11, 12, 13]),
+        admitted_encoder_slot(1, 8, 1, vec![21, 22]),
+        admitted_encoder_slot(2, 9, 2, vec![31, 32, 33, 34]),
+    ];
+
+    let first = super::next_encoder_admission_batch(&slots, &[0, 1, 2], 0, 5)
+        .expect("first encoder admission batch");
+    let second = super::next_encoder_admission_batch(&slots, &[0, 1, 2], 2, 5)
+        .expect("second encoder admission batch");
+
+    assert_eq!(
+        first,
+        super::EncoderAdmissionBatch::Ready {
+            end: 2,
+            token_count: 5,
+        }
+    );
+    assert_eq!(
+        second,
+        super::EncoderAdmissionBatch::Ready {
+            end: 3,
+            token_count: 4,
+        }
+    );
+}
+
+#[test]
+fn encoder_admission_batches_isolate_oversized_concurrent_prompt() {
+    let slots = vec![
+        admitted_encoder_slot(0, 7, 0, vec![11, 12]),
+        admitted_encoder_slot(1, 8, 1, vec![21, 22, 23, 24, 25, 26]),
+        admitted_encoder_slot(2, 9, 2, vec![31, 32, 33]),
+    ];
+
+    let first = super::next_encoder_admission_batch(&slots, &[0, 1, 2], 0, 5)
+        .expect("first encoder admission batch");
+    let oversized = super::next_encoder_admission_batch(&slots, &[0, 1, 2], 1, 5)
+        .expect("oversized encoder prompt");
+    let last = super::next_encoder_admission_batch(&slots, &[0, 1, 2], 2, 5)
+        .expect("last encoder admission batch");
+
+    assert_eq!(
+        first,
+        super::EncoderAdmissionBatch::Ready {
+            end: 1,
+            token_count: 2,
+        }
+    );
+    assert_eq!(
+        oversized,
+        super::EncoderAdmissionBatch::Oversized { requested: 6 }
+    );
+    assert_eq!(
+        last,
+        super::EncoderAdmissionBatch::Ready {
+            end: 3,
+            token_count: 3,
+        }
+    );
+}
+
+#[test]
+fn encoder_admission_batch_rejects_empty_prompt() {
     let slots = vec![admitted_encoder_slot(0, 7, 0, Vec::new())];
 
-    let error = super::encoder_batch_token_count(&slots, &[0]).expect_err("empty encoder prompt");
+    let error =
+        super::next_encoder_admission_batch(&slots, &[0], 0, 3).expect_err("empty encoder prompt");
 
     assert!(matches!(
         error,
@@ -181,10 +262,11 @@ fn encoder_batch_token_count_rejects_empty_prompt() {
 }
 
 #[test]
-fn encoder_batch_token_count_rejects_missing_sequence_id() {
+fn encoder_admission_batch_rejects_missing_sequence_id() {
     let slots = vec![admitted_encoder_slot(0, 7, -1, vec![11])];
 
-    let error = super::encoder_batch_token_count(&slots, &[0]).expect_err("missing sequence id");
+    let error =
+        super::next_encoder_admission_batch(&slots, &[0], 0, 3).expect_err("missing sequence id");
 
     assert!(matches!(
         error,

--- a/crates/sipp/src/tests/runtime/inference_runtime/lifecycle_tests.rs
+++ b/crates/sipp/src/tests/runtime/inference_runtime/lifecycle_tests.rs
@@ -15,6 +15,8 @@ fn encoder_only_enables_embedding_context_before_common_params() {
     apply_model_class_defaults(&mut config, ModelClass::EncoderOnly).expect("defaults");
 
     assert_eq!(config.context.embeddings, Some(true));
+    assert_eq!(config.context.n_batch, Some(DEFAULT_ENCODER_BATCH_SIZE));
+    assert_eq!(config.context.n_ubatch, Some(DEFAULT_ENCODER_BATCH_SIZE));
 }
 
 #[test]
@@ -27,7 +29,35 @@ fn decoder_only_and_encoder_decoder_defaults_preserve_supported_configs() {
     apply_model_class_defaults(&mut encoder_decoder_config, ModelClass::EncoderDecoder)
         .expect("encoder-decoder defaults");
     assert_eq!(encoder_decoder_config.context.embeddings, None);
+    assert_eq!(
+        encoder_decoder_config.context.n_batch,
+        Some(DEFAULT_ENCODER_BATCH_SIZE)
+    );
+    assert_eq!(
+        encoder_decoder_config.context.n_ubatch,
+        Some(DEFAULT_ENCODER_BATCH_SIZE)
+    );
     assert_eq!(encoder_decoder_config.context.n_parallel, Some(1));
+}
+
+#[test]
+fn encoder_batch_defaults_follow_n_batch_and_preserve_explicit_n_ubatch() {
+    let mut config = NativeRuntimeConfig::default();
+    config.context.n_batch = Some(1024);
+
+    apply_model_class_defaults(&mut config, ModelClass::EncoderOnly).expect("encoder defaults");
+
+    assert_eq!(config.context.n_ubatch, Some(1024));
+
+    let mut explicit_config = NativeRuntimeConfig::default();
+    explicit_config.context.n_batch = Some(1024);
+    explicit_config.context.n_ubatch = Some(256);
+
+    apply_model_class_defaults(&mut explicit_config, ModelClass::EncoderOnly)
+        .expect("explicit encoder defaults");
+
+    assert_eq!(explicit_config.context.n_batch, Some(1024));
+    assert_eq!(explicit_config.context.n_ubatch, Some(256));
 }
 
 #[test]

--- a/docs/en/reference/runtime-options.md
+++ b/docs/en/reference/runtime-options.md
@@ -93,6 +93,10 @@ uses `SIPP_PYTHON_BACKEND`, and the CLI uses `--backend`.
 | `residency` | `max_gpu_models_per_device`, `allow_cpu_models_while_gpu_loaded`, `require_gpu_lease` | GPU model residency policy for native runtimes. |
 | `observability` | `runtime_metrics`, `backend_profiling` | Runtime timing, throughput, and backend diagnostics. |
 
+Encoder-capable models default `n_ubatch` to `n_batch`, or 2048 when neither is
+configured. Each encoder prompt must fit within `n_ubatch`; concurrent prompts
+are partitioned into separate encoder batches when their combined size exceeds it.
+
 Use runtime config for stable endpoint behavior. Use request options for values
 that should vary per prompt, user action, or UI control.
 

--- a/docs/zh/reference/runtime-options.md
+++ b/docs/zh/reference/runtime-options.md
@@ -43,6 +43,8 @@ Python 和 Rust 通过各语言自己的描述符和配置类/结构体提供相
 | `residency` | `max_gpu_models_per_device`, `allow_cpu_models_while_gpu_loaded`, `require_gpu_lease` | GPU 模型驻留策略，多模型 GPU 资源分配 |
 | `observability` | `runtime_metrics`, `backend_profiling` | 运行时记录延迟、吞吐量和后端诊断数据 |
 
+支持编码器的模型默认 `n_ubatch` 等于 `n_batch`；两者均未配置时使用 2048。 每个编码器提示词都必须能放入一个 `n_ubatch`；并发提示词的总长度超过该值时，运行时会将它们分到不同的编码器批次中。
+
 运行时配置设置一次即持续生效，适用于稳定的端点行为。如果某个值因提示词、用户操作或 UI 控件不同而变化，应使用请求选项，而非在配置中写死。
 
 ## 浏览器子选项


### PR DESCRIPTION
This PR addressed an issue where encoder requests can abort the process. 

Previously, sipp combined every admitted encoder prompt and sized the batch from their total, without checking resolved n_ubatch. llama.cpp then used an unconditional `GGML_ASSERT` requiring the entire non-causal batch to fit. Now, we partition requests into batches bounded by resolved_limits.n_ubatch. Reject any individual prompt exceeding that limit before native execution because non-causal encoding cannot be microbatched. Encoder-capable models default n_ubatch to n_batch, or 2048 when both are omitted