### PR TITLE
Pin emdawnwebgpu version in emsdk

### DIFF
--- a/bindings/wasm/cmake/EmscriptenConfig.cmake
+++ b/bindings/wasm/cmake/EmscriptenConfig.cmake
@@ -264,40 +264,18 @@ endif()
 # ======================================================================================
 # WebGPU Port Configuration
 # ======================================================================================
-if(NOT EMDAWNWEBGPU_DIR)
-    set(_ce_emdawnwebgpu_candidates
-        "${CMAKE_SOURCE_DIR}/../Libs/emdawnwebgpu_pkg"
-    )
-
-    if(DEFINED EMSCRIPTEN_ROOT_PATH AND EMSCRIPTEN_ROOT_PATH)
-        list(APPEND _ce_emdawnwebgpu_candidates
-            "${EMSCRIPTEN_ROOT_PATH}/cache/ports/emdawnwebgpu/emdawnwebgpu_pkg"
-        )
+if(CE_WASM_ENABLE_WEBGPU)
+    if(NOT EMDAWNWEBGPU_DIR)
+        message(FATAL_ERROR "CE_WASM_ENABLE_WEBGPU requires EMDAWNWEBGPU_DIR")
     endif()
-
-    if(DEFINED EMSDK AND EMSDK)
-        list(APPEND _ce_emdawnwebgpu_candidates
-            "${EMSDK}/upstream/emscripten/cache/ports/emdawnwebgpu/emdawnwebgpu_pkg"
-        )
-    endif()
-
-    foreach(_ce_emdawnwebgpu_candidate IN LISTS _ce_emdawnwebgpu_candidates)
-        if(EXISTS "${_ce_emdawnwebgpu_candidate}/emdawnwebgpu.port.py")
-            set(EMDAWNWEBGPU_DIR "${_ce_emdawnwebgpu_candidate}" CACHE PATH "Path to the emdawnwebgpu port package" FORCE)
-            break()
-        endif()
-    endforeach()
-endif()
-
-if(EMDAWNWEBGPU_DIR)
     set(CE_WEBGPU_PORT "--use-port=${EMDAWNWEBGPU_DIR}/emdawnwebgpu.port.py")
 else()
-    set(CE_WEBGPU_PORT "--use-port=emdawnwebgpu")
+    set(CE_WEBGPU_PORT "disabled")
 endif()
 
-# The ggml-webgpu target injects the emdawnwebgpu port itself. Keep discovery here
-# for status output and downstream checks, but do not append the port globally or
-# Emscripten will reject the duplicated port registration.
+# The ggml-webgpu target injects the emdawnwebgpu port itself. Keep the resolved
+# flag here for status output, but do not append the port globally or Emscripten
+# will reject the duplicated port registration.
 
 # ======================================================================================
 # Status Output

--- a/xtask/src/targets/wasm.rs
+++ b/xtask/src/targets/wasm.rs
@@ -5,7 +5,7 @@ use crate::javascript;
 use crate::output;
 use crate::toolchains::bun::setup_bun;
 use crate::toolchains::cmake::setup_cmake;
-use crate::toolchains::emsdk::{run_with_emsdk, setup_emsdk};
+use crate::toolchains::emsdk::{run_with_emsdk, setup_emsdk, EmscriptenToolchain};
 use crate::toolchains::ninja::setup_ninja;
 use crate::toolchains::source::ensure_llama_cpp_submodule;
 use crate::utils::BuildContext;
@@ -28,7 +28,7 @@ pub fn build(
     output::path("WASM artifact directory", &ctx.npm_browser_wasm_dir());
 
     ensure_llama_cpp_submodule(sh, ctx)?;
-    let emsdk_dir = setup_emsdk(sh, ctx)?;
+    let emscripten = setup_emsdk(sh, ctx)?;
     let cmake_bin_dir = setup_cmake(sh, ctx)?;
     let ninja_dir = setup_ninja(sh, ctx)?;
 
@@ -48,7 +48,7 @@ pub fn build(
                 sh,
                 ctx,
                 root,
-                &emsdk_dir,
+                &emscripten,
                 &cmake_bin_dir,
                 ninja_dir.as_deref(),
                 false,
@@ -64,7 +64,7 @@ pub fn build(
                 sh,
                 ctx,
                 root,
-                &emsdk_dir,
+                &emscripten,
                 &cmake_bin_dir,
                 ninja_dir.as_deref(),
                 true,
@@ -144,7 +144,7 @@ fn build_target(
     sh: &Shell,
     ctx: &BuildContext,
     root: &Path,
-    emsdk_dir: &Path,
+    emscripten: &EmscriptenToolchain,
     cmake_bin_dir: &Path,
     ninja_dir: Option<&Path>,
     use_pthreads: bool,
@@ -190,7 +190,7 @@ fn build_target(
 
     run_with_emsdk(
         sh,
-        emsdk_dir,
+        &emscripten.emsdk_dir,
         Some(cmake_bin_dir),
         ninja_dir,
         &format!("Compiling Rust staticlib for {js_file}"),
@@ -201,6 +201,7 @@ fn build_target(
     let wasm_dir = root.join("bindings").join("wasm");
     let wasm_source_dir = ctx.cmake_file_path(&wasm_dir);
     let rust_staticlib_cmake = ctx.cmake_file_path(&rust_staticlib);
+    let emdawnwebgpu_cmake = ctx.cmake_file_path(&emscripten.emdawnwebgpu_dir);
     let build_dir = cmake_build_dir(ctx, use_pthreads, runtime_flavor);
     sh.create_dir(&build_dir)?;
     output::path("CMake build directory", &build_dir);
@@ -223,16 +224,17 @@ fn build_target(
         "-DCE_WASM_USE_JSPI=OFF"
     };
     let emcmake_cmd = format!(
-        "emcmake cmake \"{}\" -G Ninja -DCMAKE_BUILD_TYPE=Release {} {} {} -DCE_WASM_RUST_STATICLIB=\"{}\"",
+        "emcmake cmake \"{}\" -G Ninja -DCMAKE_BUILD_TYPE=Release {} {} {} -DCE_WASM_RUST_STATICLIB=\"{}\" -DEMDAWNWEBGPU_DIR=\"{}\"",
         wasm_source_dir,
         cmake_thread_flag,
         cmake_webgpu_flag,
         cmake_jspi_flag,
-        rust_staticlib_cmake
+        rust_staticlib_cmake,
+        emdawnwebgpu_cmake
     );
     run_with_emsdk(
         sh,
-        emsdk_dir,
+        &emscripten.emsdk_dir,
         Some(cmake_bin_dir),
         ninja_dir,
         &format!("Configuring CMake for {artifact_name}"),
@@ -242,7 +244,7 @@ fn build_target(
     let build_cmd = "cmake --build . --parallel";
     run_with_emsdk(
         sh,
-        emsdk_dir,
+        &emscripten.emsdk_dir,
         Some(cmake_bin_dir),
         ninja_dir,
         &format!("Building browser runtime for {artifact_name}"),

--- a/xtask/src/tests/toolchains/emsdk_tests.rs
+++ b/xtask/src/tests/toolchains/emsdk_tests.rs
@@ -6,8 +6,9 @@
 use crate::test_support::TempDir;
 
 use super::{
-    emsdk_is_active, emsdk_is_installed, expected_emsdk_tool_id, patch_emsdk_windows,
-    rust_target_list_contains, EMSDK_VERSION,
+    emdawnwebgpu_is_installed, emdawnwebgpu_package_dir, emsdk_is_active, emsdk_is_installed,
+    expected_emsdk_tool_id, patch_emsdk_windows, rust_target_list_contains, EMDAWNWEBGPU_VERSION,
+    EMSDK_VERSION,
 };
 
 #[test]
@@ -54,6 +55,36 @@ fn installed_check_rejects_wrong_version_marker() {
     temp.write("upstream/.emsdk_version", "other\n");
 
     assert!(!emsdk_is_installed(temp.path()).unwrap());
+}
+
+#[test]
+fn emdawnwebgpu_install_check_requires_port_and_version_marker() {
+    let temp = TempDir::new("emdawnwebgpu-installed");
+    let ctx = crate::utils::BuildContext::from_workspace_root_for_test(temp.path());
+    let package_dir = emdawnwebgpu_package_dir(&ctx);
+
+    assert_eq!(
+        package_dir,
+        temp.join(format!(
+            ".build/toolchain/emdawnwebgpu/{EMDAWNWEBGPU_VERSION}/emdawnwebgpu_pkg"
+        ))
+    );
+    assert!(!emdawnwebgpu_is_installed(&package_dir).unwrap());
+
+    temp.write(
+        format!(
+            ".build/toolchain/emdawnwebgpu/{EMDAWNWEBGPU_VERSION}/emdawnwebgpu_pkg/emdawnwebgpu.port.py"
+        ),
+        "",
+    );
+    temp.write(
+        format!(
+            ".build/toolchain/emdawnwebgpu/{EMDAWNWEBGPU_VERSION}/emdawnwebgpu_pkg/VERSION.txt"
+        ),
+        format!("Dawn release {EMDAWNWEBGPU_VERSION} at revision abc."),
+    );
+
+    assert!(emdawnwebgpu_is_installed(&package_dir).unwrap());
 }
 
 #[test]

--- a/xtask/src/toolchains/emsdk.rs
+++ b/xtask/src/toolchains/emsdk.rs
@@ -22,7 +22,7 @@ mod emsdk_tests;
 /////////////////////////////////////////////////////////////////////////////////
 
 const EMSDK_VERSION: &str = "5.0.6";
-const EMDAWNWEBGPU_VERSION: &str = "v20260624.223603";
+const EMDAWNWEBGPU_VERSION: &str = "v20260317.182325";
 const RUST_EMSCRIPTEN_TARGET: &str = "wasm32-unknown-emscripten";
 
 #[derive(Clone, Debug)]

--- a/xtask/src/toolchains/emsdk.rs
+++ b/xtask/src/toolchains/emsdk.rs
@@ -107,10 +107,17 @@ fn ensure_emdawnwebgpu_port(sh: &Shell, ctx: &BuildContext) -> Result<std::path:
         "Downloading emdawnwebgpu",
         cmd!(sh, "curl -f -L -o {archive_path} {url}"),
     )?;
-    output::run_command(
-        "Extracting emdawnwebgpu",
-        cmd!(sh, "tar -xf {archive_path} -C {install_dir}"),
-    )?;
+    if cfg!(windows) {
+        output::run_command(
+            "Extracting emdawnwebgpu",
+            cmd!(sh, "tar -xf {archive_path} -C {install_dir}"),
+        )?;
+    } else {
+        output::run_command(
+            "Extracting emdawnwebgpu",
+            cmd!(sh, "unzip -oq {archive_path} -d {install_dir}"),
+        )?;
+    }
     sh.remove_path(&archive_path)?;
 
     if !emdawnwebgpu_is_installed(&package_dir)? {

--- a/xtask/src/toolchains/emsdk.rs
+++ b/xtask/src/toolchains/emsdk.rs
@@ -22,10 +22,17 @@ mod emsdk_tests;
 /////////////////////////////////////////////////////////////////////////////////
 
 const EMSDK_VERSION: &str = "5.0.6";
+const EMDAWNWEBGPU_VERSION: &str = "v20260624.223603";
 const RUST_EMSCRIPTEN_TARGET: &str = "wasm32-unknown-emscripten";
 
+#[derive(Clone, Debug)]
+pub(crate) struct EmscriptenToolchain {
+    pub(crate) emsdk_dir: std::path::PathBuf,
+    pub(crate) emdawnwebgpu_dir: std::path::PathBuf,
+}
+
 /// Ensures the configured Emscripten SDK is cloned, installed, and active.
-pub(crate) fn setup_emsdk(sh: &Shell, ctx: &BuildContext) -> Result<std::path::PathBuf> {
+pub(crate) fn setup_emsdk(sh: &Shell, ctx: &BuildContext) -> Result<EmscriptenToolchain> {
     let toolchain_root = ctx.toolchain_dir();
     let emsdk_dir = toolchain_root.join("emsdk");
 
@@ -64,8 +71,81 @@ pub(crate) fn setup_emsdk(sh: &Shell, ctx: &BuildContext) -> Result<std::path::P
     }
 
     ensure_rust_emscripten_target(sh)?;
+    let emdawnwebgpu_dir = ensure_emdawnwebgpu_port(sh, ctx)?;
 
-    Ok(emsdk_dir)
+    Ok(EmscriptenToolchain {
+        emsdk_dir,
+        emdawnwebgpu_dir,
+    })
+}
+
+fn ensure_emdawnwebgpu_port(sh: &Shell, ctx: &BuildContext) -> Result<std::path::PathBuf> {
+    let package_dir = emdawnwebgpu_package_dir(ctx);
+    if emdawnwebgpu_is_installed(&package_dir)? {
+        output::success(format!(
+            "Using emdawnwebgpu {EMDAWNWEBGPU_VERSION} at {}",
+            package_dir.display()
+        ));
+        return Ok(package_dir);
+    }
+
+    let install_dir = package_dir
+        .parent()
+        .context("failed to resolve emdawnwebgpu install directory")?;
+    let archive_name = format!("emdawnwebgpu_pkg-{EMDAWNWEBGPU_VERSION}.zip");
+    let archive_path = install_dir.join(&archive_name);
+    let url = format!(
+        "https://github.com/google/dawn/releases/download/{EMDAWNWEBGPU_VERSION}/{archive_name}"
+    );
+
+    output::phase("Emdawnwebgpu WebGPU port");
+    output::detail("Version", EMDAWNWEBGPU_VERSION);
+    output::path("Install directory", install_dir);
+    sh.create_dir(install_dir)?;
+    output::detail("Download", &url);
+    output::run_command(
+        "Downloading emdawnwebgpu",
+        cmd!(sh, "curl -f -L -o {archive_path} {url}"),
+    )?;
+    output::run_command(
+        "Extracting emdawnwebgpu",
+        cmd!(sh, "tar -xf {archive_path} -C {install_dir}"),
+    )?;
+    sh.remove_path(&archive_path)?;
+
+    if !emdawnwebgpu_is_installed(&package_dir)? {
+        bail!(
+            "emdawnwebgpu {EMDAWNWEBGPU_VERSION} was not installed at {}",
+            package_dir.display()
+        );
+    }
+
+    output::success(format!(
+        "Installed emdawnwebgpu {EMDAWNWEBGPU_VERSION} at {}",
+        package_dir.display()
+    ));
+    Ok(package_dir)
+}
+
+fn emdawnwebgpu_package_dir(ctx: &BuildContext) -> std::path::PathBuf {
+    ctx.toolchain_dir()
+        .join("emdawnwebgpu")
+        .join(EMDAWNWEBGPU_VERSION)
+        .join("emdawnwebgpu_pkg")
+}
+
+fn emdawnwebgpu_is_installed(package_dir: &Path) -> Result<bool> {
+    let port_file = package_dir.join("emdawnwebgpu.port.py");
+    if !port_file.exists() {
+        return Ok(false);
+    }
+
+    let version_file = package_dir.join("VERSION.txt");
+    let Ok(version) = std::fs::read_to_string(&version_file) else {
+        return Ok(false);
+    };
+
+    Ok(version.contains(&format!("Dawn release {EMDAWNWEBGPU_VERSION}")))
 }
 
 /// Runs a command after loading the Emscripten environment.

--- a/xtask/src/toolchains/emsdk.rs
+++ b/xtask/src/toolchains/emsdk.rs
@@ -21,7 +21,7 @@ mod emsdk_tests;
 /// SRC
 /////////////////////////////////////////////////////////////////////////////////
 
-const EMSDK_VERSION: &str = "4.0.23";
+const EMSDK_VERSION: &str = "5.0.6";
 const RUST_EMSCRIPTEN_TARGET: &str = "wasm32-unknown-emscripten";
 
 /// Ensures the configured Emscripten SDK is cloned, installed, and active.

--- a/xtask/src/toolchains/ninja.rs
+++ b/xtask/src/toolchains/ninja.rs
@@ -2,7 +2,7 @@
 
 use crate::output;
 use crate::utils::BuildContext;
-use anyhow::{Context, Result};
+use anyhow::{Result};
 use std::path::{Path, PathBuf};
 use xshell::{cmd, Shell};
 

--- a/xtask/src/toolchains/ninja.rs
+++ b/xtask/src/toolchains/ninja.rs
@@ -2,7 +2,7 @@
 
 use crate::output;
 use crate::utils::BuildContext;
-use anyhow::{Result};
+use anyhow::{Context, Result};
 use std::path::{Path, PathBuf};
 use xshell::{cmd, Shell};
 


### PR DESCRIPTION
This PR pins the emdawnwebgpu version in emsdk. Previously, our path discovery methods would let llama. cpp uses Emscripten’s bundled remote port, which pointed to `v20251002.162335`. Now, we manually control the emdawnwebgpu version that we can specify in the emsdk.rs and then download and extract it in the managed .build folder.

I initially pinned it to the newest Dawn release: `v20260624.223603` That package’s generated C++ headers use C++20 features, specifically things like:
- std::type_identity
- requires (...) constraints

But vendored llama.cpp’s WebGPU backend is still compiled as C++17. The failed compile command showed:
- std=gnu++17

So clang saw C++20 syntax in webgpu_cpp.h while compiling in C++17 mode, and failed. Therefore we later pinned this to vendored llama.cpp’s own version.

---
Validation already run:

  - cargo fmt --package xtask
  - cargo test -p xtask toolchains::emsdk::emsdk_tests --lib
  - cargo check -p xtask
  - cargo xtask toolchain install emsdk
  - git diff --check
  - Manual testing with the playground