### PR TITLE
Advance 'lease_epoch' on warm reuse as well as cold admission

### DIFF
--- a/crates/sipp/src/runtime/inference_runtime/prefix_snapshots.rs
+++ b/crates/sipp/src/runtime/inference_runtime/prefix_snapshots.rs
@@ -49,7 +49,7 @@ impl InferenceRuntime {
                     self.model_fingerprint,
                     &request.context_key,
                     slot.seq_id,
-                    slot.lease_generation,
+                    slot.lease_epoch,
                     snapshot_tokens,
                     terminal_token_count,
                 );

--- a/crates/sipp/src/runtime/scheduler/slot_scheduler/flow.rs
+++ b/crates/sipp/src/runtime/scheduler/slot_scheduler/flow.rs
@@ -153,7 +153,7 @@ impl SlotScheduler {
                 kv_cache.finalize_slot(
                     &request_val.context_key,
                     slot.seq_id,
-                    slot.lease_generation,
+                    slot.lease_epoch,
                     std::mem::take(&mut slot.mirror),
                     should_commit_live,
                     cache_mode,
@@ -230,7 +230,7 @@ fn release_slot_for_reset(kv_cache: &mut KvCacheManager, slot: &SlotState) {
     let Some(request) = slot.request() else {
         return;
     };
-    kv_cache.release_slot_for_reset(&request.context_key, slot.seq_id, slot.lease_generation);
+    kv_cache.release_slot_for_reset(&request.context_key, slot.seq_id, slot.lease_epoch);
 }
 
 fn completed_slot_status(

--- a/crates/sipp/src/runtime/scheduler/slot_state/mod.rs
+++ b/crates/sipp/src/runtime/scheduler/slot_state/mod.rs
@@ -70,7 +70,7 @@ pub struct SlotState {
     pub plan: SlotExecutionPlan,
     pub request_id: GenerateRequestId,
     pub request: Option<GenerateRequest>,
-    pub lease_generation: u64,
+    pub lease_epoch: u64,
     pub cache_candidate: CacheCandidate,
     pub requires_kv_clear: bool,
     pub mirror: SequenceMirror,
@@ -109,7 +109,7 @@ impl SlotState {
         self.seq_id = -1;
         self.request_id = 0;
         self.request = None;
-        self.lease_generation = 0;
+        self.lease_epoch = 0;
         self.cache_candidate = CacheCandidate::None;
         self.requires_kv_clear = false;
         self.backend_sampler_attached = false;
@@ -127,7 +127,7 @@ impl SlotState {
         self.request_id = request.id;
         self.request = Some(request);
         self.seq_id = admission.seq_id;
-        self.lease_generation = admission.generation;
+        self.lease_epoch = admission.lease_epoch;
         self.cache_candidate = admission.candidate;
         self.requires_kv_clear = admission.requires_kv_clear;
         self.mirror = admission.mirror;
@@ -209,7 +209,7 @@ impl Default for SlotState {
             plan: SlotExecutionPlan::default(),
             request_id: 0,
             request: None,
-            lease_generation: 0,
+            lease_epoch: 0,
             cache_candidate: CacheCandidate::None,
             requires_kv_clear: false,
             mirror: SequenceMirror::default(),

--- a/crates/sipp/src/runtime/session/kv_cache_manager/mod.rs
+++ b/crates/sipp/src/runtime/session/kv_cache_manager/mod.rs
@@ -6,6 +6,7 @@ use crate::runtime::metrics::CacheSource;
 use crate::runtime::numeric::saturating_usize_to_u64;
 use crate::runtime::{llama_seq_id, llama_token};
 
+use super::prefix_cache_policy::{mix_prefix_hash_token, PREFIX_HASH_SEED};
 use super::prefix_state_cache::PendingPrefixSnapshot;
 use super::{PrefixCachePolicy, PrefixStateCache};
 
@@ -31,7 +32,7 @@ pub struct CachePreparation {
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct KvCacheAdmission {
     pub seq_id: llama_seq_id,
-    pub generation: u64,
+    pub lease_epoch: u64,
     pub mirror: SequenceMirror,
     pub candidate: CacheCandidate,
     pub requires_kv_clear: bool,
@@ -46,7 +47,7 @@ pub(crate) struct SnapshotRestore {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct ResidentRef {
     seq_id: llama_seq_id,
-    generation: u64,
+    lease_epoch: u64,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
@@ -57,7 +58,7 @@ struct SessionRecord {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct PhysicalSequence {
-    generation: u64,
+    lease_epoch: u64,
     state: SeqState,
 }
 
@@ -97,7 +98,7 @@ impl KvCacheManager {
             idle_lru: VecDeque::with_capacity(max_sequences),
             physical: (0..max_sequences)
                 .map(|_| PhysicalSequence {
-                    generation: 0,
+                    lease_epoch: 0,
                     state: SeqState::Free,
                 })
                 .collect(),
@@ -152,19 +153,25 @@ impl KvCacheManager {
         &mut self,
         context_key: &str,
         seq_id: llama_seq_id,
-        generation: u64,
+        lease_epoch: u64,
         mirror: SequenceMirror,
         completed: bool,
         mode: KvReuseMode,
     ) {
-        if !self.sequence_generation_matches(seq_id, generation) {
+        if !self.sequence_lease_epoch_matches(seq_id, lease_epoch) {
             return;
         }
 
         if completed && live_reuse_enabled(mode) {
             if let Some(index) = seq_index(seq_id, self.physical.len()) {
                 self.physical[index].state = SeqState::Idle { mirror };
-                self.set_session_idle(context_key, ResidentRef { seq_id, generation });
+                self.set_session_idle(
+                    context_key,
+                    ResidentRef {
+                        seq_id,
+                        lease_epoch,
+                    },
+                );
             }
         } else {
             self.evict_sequence(seq_id);
@@ -176,9 +183,9 @@ impl KvCacheManager {
         &mut self,
         context_key: &str,
         seq_id: llama_seq_id,
-        generation: u64,
+        lease_epoch: u64,
     ) {
-        if !self.sequence_generation_matches(seq_id, generation) {
+        if !self.sequence_lease_epoch_matches(seq_id, lease_epoch) {
             return;
         }
         self.evict_sequence(seq_id);
@@ -188,7 +195,7 @@ impl KvCacheManager {
     pub fn evict_all_active_and_idle(&mut self) {
         for index in 0..self.physical.len() {
             self.physical[index].state = SeqState::Free;
-            self.physical[index].generation = self.physical[index].generation.saturating_add(1);
+            self.physical[index].lease_epoch = self.physical[index].lease_epoch.saturating_add(1);
         }
         self.sessions.clear();
         self.idle_lru.clear();
@@ -264,7 +271,7 @@ impl KvCacheManager {
         model_fingerprint: u64,
         snapshot_scope: &str,
         seq_id: llama_seq_id,
-        generation: u64,
+        lease_epoch: u64,
         tokens: &[llama_token],
         terminal_token_count: usize,
     ) -> bool {
@@ -279,7 +286,7 @@ impl KvCacheManager {
         self.prefix_state_cache
             .enqueue_pending_snapshot(PendingPrefixSnapshot {
                 seq_id,
-                generation,
+                lease_epoch,
                 model_fingerprint,
                 snapshot_scope: snapshot_scope.to_string(),
                 token_count,
@@ -295,19 +302,13 @@ impl KvCacheManager {
         native_runtime: &NativeRuntimeHandle,
         max_to_drain: usize,
     ) -> usize {
-        let generations_by_seq: Vec<u64> = self
-            .physical
-            .iter()
-            .map(|sequence| sequence.generation)
-            .collect();
+        let physical = &self.physical;
+        let sessions = &self.sessions;
         let prefix_cache_policy = &mut self.prefix_cache_policy;
         self.prefix_state_cache.drain_pending_snapshots(
             native_runtime,
             max_to_drain,
-            |seq_id, generation| {
-                seq_index(seq_id, generations_by_seq.len())
-                    .is_some_and(|index| generations_by_seq[index] == generation)
-            },
+            |snapshot| pending_snapshot_source_is_current(snapshot, physical, sessions),
             |token_count| prefix_cache_policy.record_store(token_count),
         )
     }
@@ -320,18 +321,22 @@ impl KvCacheManager {
     fn try_admit_warm(&mut self, context_key: &str) -> Option<KvCacheAdmission> {
         let resident = self.sessions.get(context_key)?.resident?;
         let index = self.valid_resident_index(resident)?;
+        self.prefix_state_cache
+            .drop_pending_snapshots_for_seq(resident.seq_id);
         let SeqState::Idle { mirror } =
             std::mem::replace(&mut self.physical[index].state, SeqState::Leased)
         else {
             return None;
         };
+        self.physical[index].lease_epoch = self.physical[index].lease_epoch.saturating_add(1);
+        let lease_epoch = self.physical[index].lease_epoch;
         self.remove_lru_key(context_key);
         let record = self.sessions.get_mut(context_key)?;
         record.resident = None;
         record.in_flight = true;
         Some(KvCacheAdmission {
             seq_id: resident.seq_id,
-            generation: resident.generation,
+            lease_epoch,
             mirror,
             candidate: CacheCandidate::Live,
             requires_kv_clear: false,
@@ -344,7 +349,7 @@ impl KvCacheManager {
         self.prefix_state_cache
             .drop_pending_snapshots_for_seq(seq_id);
         self.physical[index].state = SeqState::Free;
-        self.physical[index].generation = self.physical[index].generation.saturating_add(1);
+        self.physical[index].lease_epoch = self.physical[index].lease_epoch.saturating_add(1);
         self.physical[index].state = SeqState::Leased;
         self.remove_lru_key(context_key);
         match self.sessions.entry(context_key.to_string()) {
@@ -362,7 +367,7 @@ impl KvCacheManager {
         }
         Some(KvCacheAdmission {
             seq_id,
-            generation: self.physical[index].generation,
+            lease_epoch: self.physical[index].lease_epoch,
             mirror: SequenceMirror::default(),
             candidate: CacheCandidate::None,
             requires_kv_clear,
@@ -440,7 +445,7 @@ impl KvCacheManager {
         self.prefix_state_cache
             .drop_pending_snapshots_for_seq(seq_id);
         self.physical[index].state = SeqState::Free;
-        self.physical[index].generation = self.physical[index].generation.saturating_add(1);
+        self.physical[index].lease_epoch = self.physical[index].lease_epoch.saturating_add(1);
     }
 
     fn prune_stale_idle_sessions(&mut self) {
@@ -496,14 +501,14 @@ impl KvCacheManager {
     fn valid_resident_index(&self, resident: ResidentRef) -> Option<usize> {
         let index = seq_index(resident.seq_id, self.physical.len())?;
         let sequence = &self.physical[index];
-        (sequence.generation == resident.generation
+        (sequence.lease_epoch == resident.lease_epoch
             && matches!(sequence.state, SeqState::Idle { .. }))
         .then_some(index)
     }
 
-    fn sequence_generation_matches(&self, seq_id: llama_seq_id, generation: u64) -> bool {
+    fn sequence_lease_epoch_matches(&self, seq_id: llama_seq_id, lease_epoch: u64) -> bool {
         seq_index(seq_id, self.physical.len())
-            .is_some_and(|index| self.physical[index].generation == generation)
+            .is_some_and(|index| self.physical[index].lease_epoch == lease_epoch)
     }
 
     fn refresh_lru_key(&mut self, context_key: &str) {
@@ -544,7 +549,85 @@ fn max_representable_sequences() -> usize {
 }
 
 fn free_sequence_requires_clear(sequence: &PhysicalSequence) -> bool {
-    sequence.generation > 0
+    sequence.lease_epoch > 0
+}
+
+fn pending_snapshot_source_is_current(
+    snapshot: &PendingPrefixSnapshot,
+    physical: &[PhysicalSequence],
+    sessions: &HashMap<String, SessionRecord>,
+) -> bool {
+    if snapshot.seq_id < 0
+        || snapshot.token_count == 0
+        || snapshot.token_count > snapshot.prefix_tokens.len()
+    {
+        return false;
+    }
+
+    let Some(index) = seq_index(snapshot.seq_id, physical.len()) else {
+        return false;
+    };
+    let sequence = &physical[index];
+    if sequence.lease_epoch != snapshot.lease_epoch {
+        return false;
+    }
+    let SeqState::Idle { mirror } = &sequence.state else {
+        return false;
+    };
+
+    let Some(record) = sessions.get(&snapshot.snapshot_scope) else {
+        return false;
+    };
+    if record.in_flight
+        || record.resident
+            != Some(ResidentRef {
+                seq_id: snapshot.seq_id,
+                lease_epoch: snapshot.lease_epoch,
+            })
+    {
+        return false;
+    }
+
+    prefix_hash_matches(
+        &snapshot.prefix_tokens,
+        snapshot.token_count,
+        snapshot.prefix_hash,
+    ) && mirror_covers_prefix(mirror, &snapshot.prefix_tokens, snapshot.token_count)
+}
+
+fn prefix_hash_matches(
+    prefix_tokens: &[llama_token],
+    token_count: usize,
+    expected_hash: u64,
+) -> bool {
+    if token_count == 0 || token_count > prefix_tokens.len() {
+        return false;
+    }
+
+    prefix_tokens[..token_count]
+        .iter()
+        .fold(PREFIX_HASH_SEED, |hash, &token| {
+            mix_prefix_hash_token(hash, token)
+        })
+        == expected_hash
+}
+
+fn mirror_covers_prefix(
+    mirror: &SequenceMirror,
+    prefix_tokens: &[llama_token],
+    token_count: usize,
+) -> bool {
+    if token_count == 0
+        || token_count > prefix_tokens.len()
+        || token_count > mirror.current_kv_tokens.len()
+    {
+        return false;
+    }
+    let Ok(n_past) = usize::try_from(mirror.n_past) else {
+        return false;
+    };
+
+    n_past >= token_count && mirror.current_kv_tokens[..token_count] == prefix_tokens[..token_count]
 }
 
 #[cfg(test)]

--- a/crates/sipp/src/runtime/session/prefix_state_cache/mod.rs
+++ b/crates/sipp/src/runtime/session/prefix_state_cache/mod.rs
@@ -40,7 +40,7 @@ pub(super) struct PrefixStateStoreRequest<'a> {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(in crate::runtime::session) struct PendingPrefixSnapshot {
     pub seq_id: llama_seq_id,
-    pub generation: u64,
+    pub lease_epoch: u64,
     pub model_fingerprint: u64,
     pub snapshot_scope: String,
     pub token_count: usize,

--- a/crates/sipp/src/runtime/session/prefix_state_cache/state_io.rs
+++ b/crates/sipp/src/runtime/session/prefix_state_cache/state_io.rs
@@ -66,7 +66,7 @@ impl PrefixStateCache {
         &mut self,
         runtime: &NativeRuntimeHandle,
         max_to_drain: usize,
-        mut sequence_is_current: impl FnMut(llama_seq_id, u64) -> bool,
+        mut snapshot_source_is_current: impl FnMut(&PendingPrefixSnapshot) -> bool,
         mut record_stored_snapshot: impl FnMut(usize),
     ) -> usize {
         if self.pending_snapshots.is_empty() {
@@ -85,7 +85,7 @@ impl PrefixStateCache {
             };
             drained += 1;
 
-            if !sequence_is_current(snapshot.seq_id, snapshot.generation) {
+            if !snapshot_source_is_current(&snapshot) {
                 continue;
             }
             let Ok(state_bytes) = runtime.state_seq(snapshot.seq_id) else {
@@ -193,7 +193,7 @@ fn same_pending_snapshot_identity(
     right: &PendingPrefixSnapshot,
 ) -> bool {
     left.seq_id == right.seq_id
-        && left.generation == right.generation
+        && left.lease_epoch == right.lease_epoch
         && left.model_fingerprint == right.model_fingerprint
         && left.snapshot_scope == right.snapshot_scope
         && left.token_count == right.token_count

--- a/crates/sipp/src/tests/runtime/scheduler/slot_scheduler/flow_tests.rs
+++ b/crates/sipp/src/tests/runtime/scheduler/slot_scheduler/flow_tests.rs
@@ -23,7 +23,7 @@ fn request(id: GenerateRequestId, context_key: &str) -> GenerateRequest {
 fn admission(seq_id: i32) -> KvCacheAdmission {
     KvCacheAdmission {
         seq_id,
-        generation: 1,
+        lease_epoch: 1,
         mirror: SequenceMirror::default(),
         candidate: CacheCandidate::None,
         requires_kv_clear: true,

--- a/crates/sipp/src/tests/runtime/scheduler/slot_state_tests.rs
+++ b/crates/sipp/src/tests/runtime/scheduler/slot_state_tests.rs
@@ -5,10 +5,10 @@
 use super::*;
 use crate::runtime::session::{CacheCandidate, KvCacheAdmission, SequenceMirror};
 
-fn admission(seq_id: i32, generation: u64, tokens: Vec<i32>) -> KvCacheAdmission {
+fn admission(seq_id: i32, lease_epoch: u64, tokens: Vec<i32>) -> KvCacheAdmission {
     KvCacheAdmission {
         seq_id,
-        generation,
+        lease_epoch,
         mirror: SequenceMirror {
             n_past: tokens.len() as i32,
             current_kv_tokens: tokens,
@@ -36,7 +36,7 @@ fn attach_request_copies_session_mirror_and_resets_slot_progress() {
     assert_eq!(slot.slot_id, 3);
     assert_eq!(slot.request_id, 42);
     assert_eq!(slot.seq_id, 7);
-    assert_eq!(slot.lease_generation, 11);
+    assert_eq!(slot.lease_epoch, 11);
     assert_eq!(slot.cache_candidate, CacheCandidate::Live);
     assert!(!slot.requires_kv_clear);
     assert_eq!(slot.phase, SlotPhase::Admitted);
@@ -60,7 +60,7 @@ fn reset_to_idle_clears_request_and_runtime_buffers() {
 
     assert_eq!(slot.phase, SlotPhase::Idle);
     assert_eq!(slot.seq_id, -1);
-    assert_eq!(slot.lease_generation, 0);
+    assert_eq!(slot.lease_epoch, 0);
     assert_eq!(slot.cache_candidate, CacheCandidate::None);
     assert!(!slot.requires_kv_clear);
     assert_eq!(slot.request_id, 0);

--- a/crates/sipp/src/tests/runtime/session/kv_cache_manager_tests.rs
+++ b/crates/sipp/src/tests/runtime/session/kv_cache_manager_tests.rs
@@ -45,7 +45,7 @@ fn warm_reuse_moves_idle_tokens_into_admission_mirror() {
     manager.finalize_slot(
         "ctx",
         cold.seq_id,
-        cold.generation,
+        cold.lease_epoch,
         mirror(&[1, 2, 3, 4]),
         true,
         KvReuseMode::LiveSlotPrefix,
@@ -56,7 +56,7 @@ fn warm_reuse_moves_idle_tokens_into_admission_mirror() {
         .expect("warm admission");
     assert_eq!(warm.candidate, CacheCandidate::Live);
     assert_eq!(warm.seq_id, cold.seq_id);
-    assert_eq!(warm.generation, cold.generation);
+    assert!(warm.lease_epoch > cold.lease_epoch);
     assert!(!warm.requires_kv_clear);
     assert_eq!(warm.mirror.current_kv_tokens, vec![1, 2, 3, 4]);
 }
@@ -71,7 +71,7 @@ fn stale_resident_ref_never_reuses_reassigned_sequence() {
     manager.finalize_slot(
         "a",
         a.seq_id,
-        a.generation,
+        a.lease_epoch,
         mirror(&[1, 2, 3]),
         true,
         KvReuseMode::LiveSlotPrefix,
@@ -82,12 +82,12 @@ fn stale_resident_ref_never_reuses_reassigned_sequence() {
         .expect("b admission");
     assert_eq!(b.candidate, CacheCandidate::None);
     assert_eq!(b.seq_id, a.seq_id);
-    assert!(b.generation > a.generation);
+    assert!(b.lease_epoch > a.lease_epoch);
     assert!(b.requires_kv_clear);
     manager.finalize_slot(
         "b",
         b.seq_id,
-        b.generation,
+        b.lease_epoch,
         mirror(&[9, 8, 7]),
         true,
         KvReuseMode::LiveSlotPrefix,
@@ -98,7 +98,7 @@ fn stale_resident_ref_never_reuses_reassigned_sequence() {
         .expect("a return admission");
     assert_eq!(a_return.candidate, CacheCandidate::None);
     assert_eq!(a_return.seq_id, a.seq_id);
-    assert!(a_return.generation > b.generation);
+    assert!(a_return.lease_epoch > b.lease_epoch);
     assert!(a_return.requires_kv_clear);
     assert!(a_return.mirror.current_kv_tokens.is_empty());
 }
@@ -113,7 +113,7 @@ fn disabled_mode_success_evicts_live_residency() {
     manager.finalize_slot(
         "ctx",
         admission.seq_id,
-        admission.generation,
+        admission.lease_epoch,
         mirror(&[1, 2, 3]),
         true,
         KvReuseMode::Disabled,
@@ -123,7 +123,7 @@ fn disabled_mode_success_evicts_live_residency() {
         .admit("ctx", KvReuseMode::LiveSlotPrefix, false)
         .expect("next admission");
     assert_eq!(next.candidate, CacheCandidate::None);
-    assert!(next.generation > admission.generation);
+    assert!(next.lease_epoch > admission.lease_epoch);
     assert!(next.requires_kv_clear);
     assert!(next.mirror.current_kv_tokens.is_empty());
 }
@@ -140,19 +140,19 @@ fn can_admit_is_false_when_every_sequence_is_leased() {
 }
 
 #[test]
-fn forced_reset_releases_in_flight_state_and_bumps_generation() {
+fn forced_reset_releases_in_flight_state_and_bumps_lease_epoch() {
     let mut manager = KvCacheManager::new(1);
 
     let admission = manager
         .admit("ctx", KvReuseMode::LiveSlotPrefix, false)
         .expect("admission");
-    manager.release_slot_for_reset("ctx", admission.seq_id, admission.generation);
+    manager.release_slot_for_reset("ctx", admission.seq_id, admission.lease_epoch);
 
     let next = manager
         .admit("ctx", KvReuseMode::LiveSlotPrefix, false)
         .expect("next admission");
     assert_eq!(next.candidate, CacheCandidate::None);
-    assert!(next.generation > admission.generation);
+    assert!(next.lease_epoch > admission.lease_epoch);
     assert!(next.requires_kv_clear);
 }
 
@@ -163,18 +163,18 @@ fn stale_finalize_does_not_overwrite_new_lease() {
     let stale = manager
         .admit("stale", KvReuseMode::LiveSlotPrefix, false)
         .expect("stale admission");
-    manager.release_slot_for_reset("stale", stale.seq_id, stale.generation);
+    manager.release_slot_for_reset("stale", stale.seq_id, stale.lease_epoch);
 
     let current = manager
         .admit("current", KvReuseMode::LiveSlotPrefix, false)
         .expect("current admission");
-    assert!(current.generation > stale.generation);
+    assert!(current.lease_epoch > stale.lease_epoch);
     assert!(current.requires_kv_clear);
 
     manager.finalize_slot(
         "stale",
         stale.seq_id,
-        stale.generation,
+        stale.lease_epoch,
         mirror(&[1, 2, 3]),
         true,
         KvReuseMode::LiveSlotPrefix,
@@ -190,29 +190,29 @@ fn stale_finalize_does_not_overwrite_new_lease() {
 }
 
 #[test]
-fn stale_generation_callbacks_do_not_clear_new_same_context_lease() {
+fn stale_lease_epoch_callbacks_do_not_clear_new_same_context_lease() {
     let mut manager = KvCacheManager::new(1);
 
     let stale = manager
         .admit("ctx", KvReuseMode::LiveSlotPrefix, false)
         .expect("stale admission");
-    manager.release_slot_for_reset("ctx", stale.seq_id, stale.generation);
+    manager.release_slot_for_reset("ctx", stale.seq_id, stale.lease_epoch);
 
     let current = manager
         .admit("ctx", KvReuseMode::LiveSlotPrefix, false)
         .expect("current admission");
-    assert!(current.generation > stale.generation);
+    assert!(current.lease_epoch > stale.lease_epoch);
     assert!(current.requires_kv_clear);
 
     manager.finalize_slot(
         "ctx",
         stale.seq_id,
-        stale.generation,
+        stale.lease_epoch,
         mirror(&[1, 2, 3]),
         true,
         KvReuseMode::LiveSlotPrefix,
     );
-    manager.release_slot_for_reset("ctx", stale.seq_id, stale.generation);
+    manager.release_slot_for_reset("ctx", stale.seq_id, stale.lease_epoch);
 
     let index = usize::try_from(current.seq_id).expect("current seq index");
     assert!(matches!(manager.physical[index].state, SeqState::Leased));
@@ -232,7 +232,7 @@ fn bypass_cache_forces_cold_admission_even_with_live_resident() {
     manager.finalize_slot(
         "ctx",
         initial.seq_id,
-        initial.generation,
+        initial.lease_epoch,
         mirror(&[1, 2, 3]),
         true,
         KvReuseMode::LiveSlotPrefix,
@@ -242,7 +242,7 @@ fn bypass_cache_forces_cold_admission_even_with_live_resident() {
         .admit("ctx", KvReuseMode::LiveSlotPrefix, true)
         .expect("bypass admission");
     assert_eq!(bypass.candidate, CacheCandidate::None);
-    assert!(bypass.generation > initial.generation);
+    assert!(bypass.lease_epoch > initial.lease_epoch);
     assert!(bypass.requires_kv_clear);
     assert!(bypass.mirror.current_kv_tokens.is_empty());
 }
@@ -257,7 +257,7 @@ fn lru_scan_drops_stale_residents_and_evicts_only_valid_idle_sequence() {
     manager.finalize_slot(
         "stale",
         stale.seq_id,
-        stale.generation,
+        stale.lease_epoch,
         mirror(&[1, 2, 3]),
         true,
         KvReuseMode::LiveSlotPrefix,
@@ -268,13 +268,13 @@ fn lru_scan_drops_stale_residents_and_evicts_only_valid_idle_sequence() {
     manager.finalize_slot(
         "valid",
         valid.seq_id,
-        valid.generation,
+        valid.lease_epoch,
         mirror(&[4, 5, 6]),
         true,
         KvReuseMode::LiveSlotPrefix,
     );
 
-    manager.physical[usize::try_from(stale.seq_id).expect("stale seq index")].generation += 1;
+    manager.physical[usize::try_from(stale.seq_id).expect("stale seq index")].lease_epoch += 1;
     manager.idle_lru.clear();
     manager.idle_lru.push_back("stale".to_string());
     manager.idle_lru.push_back("valid".to_string());
@@ -283,7 +283,7 @@ fn lru_scan_drops_stale_residents_and_evicts_only_valid_idle_sequence() {
         SessionRecord {
             resident: Some(ResidentRef {
                 seq_id: stale.seq_id,
-                generation: stale.generation,
+                lease_epoch: stale.lease_epoch,
             }),
             in_flight: false,
         },
@@ -316,7 +316,7 @@ fn state_snapshot_success_does_not_keep_live_residency() {
     manager.finalize_slot(
         "ctx",
         admission.seq_id,
-        admission.generation,
+        admission.lease_epoch,
         mirror(&[1, 2, 3]),
         true,
         KvReuseMode::StateSnapshot,
@@ -326,7 +326,7 @@ fn state_snapshot_success_does_not_keep_live_residency() {
         .admit("ctx", KvReuseMode::LiveSlotPrefix, false)
         .expect("next admission");
     assert_eq!(next.candidate, CacheCandidate::None);
-    assert!(next.generation > admission.generation);
+    assert!(next.lease_epoch > admission.lease_epoch);
     assert!(next.requires_kv_clear);
     assert!(next.mirror.current_kv_tokens.is_empty());
 }
@@ -341,7 +341,7 @@ fn failed_slot_evicts_live_residency() {
     manager.finalize_slot(
         "ctx",
         admission.seq_id,
-        admission.generation,
+        admission.lease_epoch,
         mirror(&[1, 2, 3]),
         false,
         KvReuseMode::LiveSlotPrefix,
@@ -351,7 +351,7 @@ fn failed_slot_evicts_live_residency() {
         .admit("ctx", KvReuseMode::LiveSlotPrefix, false)
         .expect("next admission");
     assert_eq!(next.candidate, CacheCandidate::None);
-    assert!(next.generation > admission.generation);
+    assert!(next.lease_epoch > admission.lease_epoch);
     assert!(next.requires_kv_clear);
 }
 
@@ -367,13 +367,48 @@ fn queued_snapshot_is_dropped_when_sequence_is_released() {
         7,
         "ctx",
         admission.seq_id,
-        admission.generation,
+        admission.lease_epoch,
         &[1, 2],
         2,
     ));
     assert_eq!(manager.pending_prefix_snapshot_count(), 1);
 
-    manager.release_slot_for_reset("ctx", admission.seq_id, admission.generation);
+    manager.release_slot_for_reset("ctx", admission.seq_id, admission.lease_epoch);
 
+    assert_eq!(manager.pending_prefix_snapshot_count(), 0);
+}
+
+#[test]
+fn warm_reuse_invalidates_pending_snapshot_and_advances_lease_epoch() {
+    let mut manager = KvCacheManager::new(1);
+
+    let admission = manager
+        .admit("ctx", KvReuseMode::LiveSlotAndSnapshot, false)
+        .expect("admission");
+    assert!(manager.queue_prefix_snapshot(
+        7,
+        "ctx",
+        admission.seq_id,
+        admission.lease_epoch,
+        &[1, 2],
+        2,
+    ));
+    manager.finalize_slot(
+        "ctx",
+        admission.seq_id,
+        admission.lease_epoch,
+        mirror(&[1, 2, 3]),
+        true,
+        KvReuseMode::LiveSlotAndSnapshot,
+    );
+    assert_eq!(manager.pending_prefix_snapshot_count(), 1);
+
+    let warm = manager
+        .admit("ctx", KvReuseMode::LiveSlotAndSnapshot, false)
+        .expect("warm admission");
+
+    assert_eq!(warm.candidate, CacheCandidate::Live);
+    assert_eq!(warm.seq_id, admission.seq_id);
+    assert!(warm.lease_epoch > admission.lease_epoch);
     assert_eq!(manager.pending_prefix_snapshot_count(), 0);
 }

--- a/crates/sipp/src/tests/runtime/session/prefix_state_cache/state_io_tests.rs
+++ b/crates/sipp/src/tests/runtime/session/prefix_state_cache/state_io_tests.rs
@@ -29,13 +29,13 @@ fn request<'a>(
 
 fn pending_snapshot(
     seq_id: i32,
-    generation: u64,
+    lease_epoch: u64,
     snapshot_scope: &str,
     tokens: Vec<i32>,
 ) -> PendingPrefixSnapshot {
     PendingPrefixSnapshot {
         seq_id,
-        generation,
+        lease_epoch,
         model_fingerprint: 7,
         snapshot_scope: snapshot_scope.to_string(),
         token_count: tokens.len(),
@@ -125,13 +125,13 @@ fn drop_pending_snapshots_for_seq_removes_only_matching_sequence() {
 }
 
 #[test]
-fn drain_pending_snapshots_drops_stale_generation_without_store() {
+fn drain_pending_snapshots_drops_stale_source_without_store() {
     let mut cache = PrefixStateCache::new(4, 1024);
     let runtime = NativeRuntimeHandle::empty_for_tests();
     cache.enqueue_pending_snapshot(pending_snapshot(0, 11, "ctx", vec![1, 2]));
 
     let drained =
-        cache.drain_pending_snapshots(&runtime, 2, |_seq_id, generation| generation == 12, |_| {});
+        cache.drain_pending_snapshots(&runtime, 2, |snapshot| snapshot.lease_epoch == 12, |_| {});
 
     assert_eq!(drained, 1);
     assert_eq!(cache.pending_snapshot_count(), 0);


### PR DESCRIPTION
This PR addressed an issue with deferred live snapshots. 

Deferred live snapshots can store one request’s native state under another request’s prefix. Pending snapshots record (seq_id, generation) but drain validation before reading the sequence’s current state. If the sequence is reused before draining the cache becomes silently inconsistent.

This PR renamed the lifecycle identity from generation to lease_epoch, advanced lease_epoch on warm reuse as well as cold admission. invalidated pending snapshots before re-leasing a warm sequence and changed pending snapshot drain validation to require multiple states. 