### PR TITLE
Add CI-managed SwiftPM distribution

### DIFF
--- a/.agents/build/instructions.md
+++ b/.agents/build/instructions.md
@@ -37,11 +37,14 @@ cargo xtask build wasm
 ```
 
 ### 5. Swift Package
-Builds the macOS and iOS XCFramework, tests the staged Swift package, builds the
-Swift examples, and assembles the signed sandbox app. This target requires
-macOS, Xcode, the Apple Rust targets, and initialized submodules.
+Builds the macOS and iOS XCFramework, validates the staged package for macOS,
+iOS, and iOS Simulator, and creates the distribution archive and checksum. Use
+`--examples` only when local CLI, SwiftUI, and iOS example artifacts are also
+needed. This target requires macOS, Xcode, the Apple Rust targets, and
+initialized submodules.
 ```bash
 cargo xtask build swift
+cargo xtask build swift --examples
 ```
 The backend is fixed per platform slice; the command has no backend selector.
 

--- a/.github/scripts/release-versions.mjs
+++ b/.github/scripts/release-versions.mjs
@@ -67,7 +67,7 @@ function selectDevVersion({
   const baseVersion =
     latestRelease == null
       ? sourceBaseVersion
-      : `${latestRelease.major}.${latestRelease.minor}.${latestRelease.patch}`;
+      : `${latestRelease.major}.${latestRelease.minor}.${latestRelease.patch + 1}`;
   requireStableVersion(baseVersion, 'Dev base version');
 
   const tagScope = packageName === 'all' ? '' : `-${packageName}`;
@@ -77,10 +77,11 @@ function selectDevVersion({
     .map((tag) => ({
       number: Number(tag.slice(devPrefix.length)),
       tag,
-    }))
+    }));
+  const validDevTags = existingDevTags
     .filter(({ number }) => Number.isInteger(number) && number > 0)
     .sort((left, right) => left.number - right.number);
-  const latestDev = existingDevTags.at(-1);
+  const latestDev = validDevTags.at(-1);
   const dev = latestDev == null ? 1 : latestDev.number + 1;
   const npmVersion = `${baseVersion}-dev${dev}`;
   const pythonVersion = `${baseVersion}.dev${dev}`;

--- a/.github/scripts/swift-distribution.mjs
+++ b/.github/scripts/swift-distribution.mjs
@@ -1,0 +1,238 @@
+import {
+  cpSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { resolve, sep } from "node:path";
+
+const archiveName = "SippCore.xcframework.zip";
+const managedPaths = [
+  "Binary",
+  "LICENSE",
+  "Package.swift",
+  "README.md",
+  "SIPP_SOURCE_REVISION",
+  "Sources",
+  "Tests",
+];
+const requiredSnapshotPaths = [
+  "LICENSE",
+  "Package.swift",
+  "README.md",
+  "SIPP_SOURCE_REVISION",
+  "Sources",
+  "Tests",
+];
+const localBinaryTarget =
+  /\.binaryTarget\(\s*name:\s*"SippCore",\s*path:\s*"Binary\/SippCore\.xcframework"\s*\)/g;
+
+function stageSwiftDistribution({
+  checksum,
+  destination,
+  distributionReadme,
+  license,
+  sourcePackage,
+  sourceRepository,
+  sourceRevision,
+  version,
+  distributionRepository,
+}) {
+  requireMatch(
+    distributionRepository,
+    /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/,
+    "SWIFT_DISTRIBUTION_REPOSITORY",
+  );
+  requireMatch(
+    sourceRepository,
+    /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/,
+    "SIPP_SOURCE_REPOSITORY",
+  );
+  requireMatch(
+    version,
+    /^\d+\.\d+\.\d+(?:-[0-9A-Za-z]+(?:[.-][0-9A-Za-z]+)*)?$/,
+    "SWIFT_VERSION",
+  );
+  requireMatch(checksum, /^[0-9a-fA-F]{64}$/, "SWIFT_CHECKSUM");
+  requireMatch(sourceRevision, /^[0-9a-f]{40}$/, "SIPP_SOURCE_REVISION");
+
+  const sourceRoot = resolve(sourcePackage);
+  const destinationRoot = resolve(destination);
+  const manifestPath = resolveManagedPath(sourceRoot, "Package.swift");
+  const generatedBindings = resolveManagedPath(
+    sourceRoot,
+    "Sources/SippCoreBindings/Generated/SippCoreBindings.swift",
+  );
+  for (const requiredPath of [
+    manifestPath,
+    generatedBindings,
+    resolveManagedPath(sourceRoot, "Sources"),
+    resolveManagedPath(sourceRoot, "Tests"),
+    resolve(distributionReadme),
+    resolve(license),
+  ]) {
+    if (!existsSync(requiredPath)) {
+      throw new Error(
+        `Required Swift distribution input is missing: ${requiredPath}`,
+      );
+    }
+  }
+
+  const archiveUrl =
+    `https://github.com/${distributionRepository}/releases/download/` +
+    `${version}/${archiveName}`;
+  const sourceManifest = readFileSync(manifestPath, "utf8");
+  const matches = [...sourceManifest.matchAll(localBinaryTarget)];
+  if (matches.length !== 1) {
+    throw new Error(
+      `Expected exactly one local SippCore binary target in ${manifestPath}, ` +
+        `found ${matches.length}`,
+    );
+  }
+  const distributionManifest = sourceManifest.replace(
+    localBinaryTarget,
+    [
+      ".binaryTarget(",
+      '            name: "SippCore",',
+      `            url: "${archiveUrl}",`,
+      `            checksum: "${checksum.toLowerCase()}"`,
+      "        )",
+    ].join("\n"),
+  );
+
+  mkdirSync(destinationRoot, { recursive: true });
+  for (const relativePath of managedPaths) {
+    rmSync(resolveManagedPath(destinationRoot, relativePath), {
+      force: true,
+      recursive: true,
+    });
+  }
+
+  cpSync(
+    resolveManagedPath(sourceRoot, "Sources"),
+    resolveManagedPath(destinationRoot, "Sources"),
+    { recursive: true },
+  );
+  cpSync(
+    resolveManagedPath(sourceRoot, "Tests"),
+    resolveManagedPath(destinationRoot, "Tests"),
+    { recursive: true },
+  );
+  cpSync(
+    resolve(distributionReadme),
+    resolveManagedPath(destinationRoot, "README.md"),
+  );
+  cpSync(resolve(license), resolveManagedPath(destinationRoot, "LICENSE"));
+  writeFileSync(
+    resolveManagedPath(destinationRoot, "Package.swift"),
+    distributionManifest,
+  );
+  writeFileSync(
+    resolveManagedPath(destinationRoot, "SIPP_SOURCE_REVISION"),
+    [
+      `repository=https://github.com/${sourceRepository}`,
+      `revision=${sourceRevision}`,
+      `version=${version}`,
+      `artifact=${archiveName}`,
+      `artifact_sha256=${checksum.toLowerCase()}`,
+      "",
+    ].join("\n"),
+  );
+
+  return {
+    archiveName,
+    archiveUrl,
+    destination: destinationRoot,
+  };
+}
+
+function syncSwiftDistribution({ destination, source }) {
+  const sourceRoot = resolve(source);
+  const destinationRoot = resolve(destination);
+  if (sourceRoot === destinationRoot) {
+    throw new Error("Swift distribution source and destination must differ");
+  }
+
+  for (const relativePath of requiredSnapshotPaths) {
+    const sourcePath = resolveManagedPath(sourceRoot, relativePath);
+    if (!existsSync(sourcePath)) {
+      throw new Error(`Swift distribution snapshot is missing: ${sourcePath}`);
+    }
+  }
+
+  mkdirSync(destinationRoot, { recursive: true });
+  for (const relativePath of managedPaths) {
+    const sourcePath = resolveManagedPath(sourceRoot, relativePath);
+    const destinationPath = resolveManagedPath(destinationRoot, relativePath);
+    rmSync(destinationPath, { force: true, recursive: true });
+    if (existsSync(sourcePath)) {
+      cpSync(sourcePath, destinationPath, { recursive: true });
+    }
+  }
+}
+
+function resolveManagedPath(root, relativePath) {
+  const resolvedRoot = resolve(root);
+  const path = resolve(resolvedRoot, relativePath);
+  if (path !== resolvedRoot && !path.startsWith(`${resolvedRoot}${sep}`)) {
+    throw new Error(`Managed path escapes ${resolvedRoot}: ${relativePath}`);
+  }
+  return path;
+}
+
+function requireMatch(value, pattern, name) {
+  if (!pattern.test(value)) {
+    throw new Error(`${name} has an invalid value: ${value}`);
+  }
+}
+
+function requiredEnvironment(name) {
+  const value = process.env[name];
+  if (value == null || value === "") {
+    throw new Error(`${name} is required`);
+  }
+  return value;
+}
+
+function main() {
+  const command = process.argv[2];
+  if (command === "sync") {
+    syncSwiftDistribution({
+      destination: requiredEnvironment("SWIFT_DISTRIBUTION_DIR"),
+      source: requiredEnvironment("SWIFT_DISTRIBUTION_SOURCE"),
+    });
+    return;
+  }
+
+  if (command === "stage") {
+    const result = stageSwiftDistribution({
+      checksum: requiredEnvironment("SWIFT_CHECKSUM"),
+      destination: requiredEnvironment("SWIFT_DISTRIBUTION_DIR"),
+      distributionReadme:
+        process.env.SWIFT_DISTRIBUTION_README ??
+        "lib/swift/Distribution/README.md",
+      distributionRepository: requiredEnvironment(
+        "SWIFT_DISTRIBUTION_REPOSITORY",
+      ),
+      license: process.env.SIPP_LICENSE ?? "LICENSE",
+      sourcePackage: requiredEnvironment("SWIFT_PACKAGE_SOURCE"),
+      sourceRepository:
+        process.env.SIPP_SOURCE_REPOSITORY ?? "noumena-labs/Sipp",
+      sourceRevision: requiredEnvironment("SIPP_SOURCE_REVISION"),
+      version: requiredEnvironment("SWIFT_VERSION"),
+    });
+    console.error(
+      `Staged Swift ${requiredEnvironment("SWIFT_VERSION")} in ` +
+        `${result.destination} for ${result.archiveUrl}`,
+    );
+    return;
+  }
+
+  throw new Error(
+    `Unknown Swift distribution command: ${command ?? "(missing)"}`,
+  );
+}
+
+main();

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -311,6 +311,47 @@ jobs:
       - name: Run Python package unit suite
         run: cargo xtask --plain test unit --no-coverage suite python-package --backend cpu
 
+  internal-swift:
+    name: Internal Swift tests
+    if: ${{ github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) }}
+    runs-on: macos-14
+    timeout-minutes: 240
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6.0.2
+        with:
+          submodules: recursive
+
+      - name: Set up Rust with Apple targets
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-apple-darwin,x86_64-apple-darwin,aarch64-apple-ios,aarch64-apple-ios-sim,x86_64-apple-ios
+
+      - name: Set up CMake and Ninja
+        uses: lukka/get-cmake@v4.3.1
+
+      - name: Set up compiler cache
+        uses: hendrikmuhs/ccache-action@v1.2.23
+        with:
+          key: ci-swift
+          max-size: 3G
+
+      - name: Cache Cargo and Swift native build outputs
+        uses: actions/cache@v5.0.5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            .build/cargo
+            .build/cmake
+            .build/c
+          key: cargo-ci-swift-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('Cargo.lock', '.cargo/config.toml', 'crates/**/Cargo.toml', 'lib/**/Cargo.toml', 'xtask/Cargo.toml', 'bindings/**/Cargo.toml') }}
+          restore-keys: |
+            cargo-ci-swift-${{ runner.os }}-${{ runner.arch }}-
+
+      - name: Run Swift package unit suite
+        run: cargo xtask --plain test unit --no-coverage suite swift-package
+
   internal-validate:
     name: Internal CI gate
     if: ${{ always() && (github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)) }}
@@ -320,6 +361,7 @@ jobs:
       - internal-browser
       - internal-node
       - internal-python
+      - internal-swift
     steps:
       - name: Check internal job results
         env:
@@ -327,10 +369,11 @@ jobs:
           BROWSER_RESULT: ${{ needs.internal-browser.result }}
           NODE_RESULT: ${{ needs.internal-node.result }}
           PYTHON_RESULT: ${{ needs.internal-python.result }}
+          SWIFT_RESULT: ${{ needs.internal-swift.result }}
         run: |
           set -euo pipefail
-          if [ "$RUST_RESULT" != "success" ] || [ "$BROWSER_RESULT" != "success" ] || [ "$NODE_RESULT" != "success" ] || [ "$PYTHON_RESULT" != "success" ]; then
-            echo "::error::Internal CI failed: rust=$RUST_RESULT browser=$BROWSER_RESULT node=$NODE_RESULT python=$PYTHON_RESULT"
+          if [ "$RUST_RESULT" != "success" ] || [ "$BROWSER_RESULT" != "success" ] || [ "$NODE_RESULT" != "success" ] || [ "$PYTHON_RESULT" != "success" ] || [ "$SWIFT_RESULT" != "success" ]; then
+            echo "::error::Internal CI failed: rust=$RUST_RESULT browser=$BROWSER_RESULT node=$NODE_RESULT python=$PYTHON_RESULT swift=$SWIFT_RESULT"
             exit 1
           fi
           echo "Internal CI passed."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -322,10 +322,8 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Set up Rust with Apple targets
+      - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: aarch64-apple-darwin,x86_64-apple-darwin,aarch64-apple-ios,aarch64-apple-ios-sim,x86_64-apple-ios
 
       - name: Set up CMake and Ninja
         uses: lukka/get-cmake@v4.3.1

--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -14,8 +14,9 @@ on:
           - node-npm
           - python
           - rust
+          - swift
       dry_run:
-        description: Build and dry-run publish without publishing npm packages
+        description: Build and dry-run publish without publishing packages
         required: false
         default: true
         type: boolean
@@ -80,7 +81,8 @@ jobs:
               true
           )"
           dev_versions="$(
-            REMOTE_RELEASE_TAGS="$remote_release_tags" REMOTE_DEV_TAGS="$remote_dev_tags" \
+            REMOTE_RELEASE_TAGS="$remote_release_tags" \
+              REMOTE_DEV_TAGS="$remote_dev_tags" \
               node .github/scripts/release-versions.mjs select-dev
           )"
           IFS='|' read -r NPM_VERSION PYTHON_VERSION DEV_TAG LATEST_RELEASE_TAG LATEST_DEV_TAG <<< "$dev_versions"
@@ -521,6 +523,28 @@ jobs:
           path: .build/artifacts/rust/*.tar.gz
           retention-days: 7
 
+  swift:
+    name: Build and publish Swift package
+    needs:
+      - gate
+      - prepare-dev
+    if: ${{ inputs.package == 'all' || inputs.package == 'swift' }}
+    permissions:
+      actions: read
+      contents: read
+    uses: ./.github/workflows/swift-distribution.yml
+    with:
+      artifact_name: sipp-swift-dev
+      build: true
+      publish: ${{ inputs.dry_run == false }}
+      prerelease: true
+      python_version: ${{ needs.prepare-dev.outputs.python_version }}
+      source_revision: ${{ github.sha }}
+      swift_distribution_app_client_id: ${{ vars.SWIFT_DISTRIBUTION_APP_CLIENT_ID }}
+      version: ${{ needs.prepare-dev.outputs.version }}
+    secrets:
+      swift_distribution_app_private_key: ${{ secrets.SWIFT_DISTRIBUTION_APP_PRIVATE_KEY }}
+
   tag-dev:
     name: Tag dev build
     runs-on: ubuntu-24.04
@@ -531,6 +555,7 @@ jobs:
       - native
       - node-npm
       - rust-source
+      - swift
     if: >-
       ${{
         always() &&
@@ -542,7 +567,8 @@ jobs:
             needs.web-npm.result == 'success' &&
             needs.native.result == 'success' &&
             needs.node-npm.result == 'success' &&
-            needs.rust-source.result == 'success'
+            needs.rust-source.result == 'success' &&
+            needs.swift.result == 'success'
           ) ||
           (
             inputs.package == 'web-npm' &&
@@ -561,6 +587,10 @@ jobs:
             inputs.package == 'rust' &&
             needs.native.result == 'success' &&
             needs.rust-source.result == 'success'
+          ) ||
+          (
+            inputs.package == 'swift' &&
+            needs.swift.result == 'success'
           )
         )
       }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,7 @@ on:
           - node-npm
           - python
           - rust
+          - swift
       release_version:
         description: Release version to publish; use auto for the next patch after the latest sipp-v* tag
         required: true
@@ -111,6 +112,8 @@ jobs:
           CARGO_REGISTRY_TOKEN_PRESENT: ${{ secrets.CARGO_REGISTRY_TOKEN != '' }}
           NPM_TOKEN_PRESENT: ${{ secrets.NPM_TOKEN != '' }}
           PYPI_API_TOKEN_PRESENT: ${{ secrets.PYPI_API_TOKEN != '' }}
+          SWIFT_APP_CLIENT_ID_PRESENT: ${{ vars.SWIFT_DISTRIBUTION_APP_CLIENT_ID != '' }}
+          SWIFT_APP_PRIVATE_KEY_PRESENT: ${{ secrets.SWIFT_DISTRIBUTION_APP_PRIVATE_KEY != '' }}
         run: |
           set -euo pipefail
           missing=0
@@ -124,6 +127,14 @@ jobs:
           fi
           if [ "$PYPI_API_TOKEN_PRESENT" != "true" ]; then
             echo "::error::PYPI_API_TOKEN is required for the first PyPI release."
+            missing=1
+          fi
+          if [ "$SWIFT_APP_CLIENT_ID_PRESENT" != "true" ]; then
+            echo "::error::SWIFT_DISTRIBUTION_APP_CLIENT_ID is required to publish Sipp-Swift."
+            missing=1
+          fi
+          if [ "$SWIFT_APP_PRIVATE_KEY_PRESENT" != "true" ]; then
+            echo "::error::SWIFT_DISTRIBUTION_APP_PRIVATE_KEY is required to publish Sipp-Swift."
             missing=1
           fi
           exit "$missing"
@@ -240,6 +251,25 @@ jobs:
             fi
           }
 
+          check_swift() {
+            local version="$1" tag_sha
+            tag_sha="$(
+              GIT_TERMINAL_PROMPT=0 git ls-remote \
+                --tags \
+                --refs \
+                https://github.com/noumena-labs/Sipp-Swift.git \
+                "refs/tags/$version" |
+                awk '{ print $1 }' ||
+                true
+            )"
+            if [ -n "$tag_sha" ]; then
+              echo "::${level}::Sipp-Swift $version is already published; bump the version before releasing."
+              conflicts=1
+            else
+              echo "Sipp-Swift $version is not yet published."
+            fi
+          }
+
           if [ "$PACKAGE" = "all" ] || [ "$PACKAGE" = "web-npm" ]; then
             check_npm @sipphq/sipp "$VERSION"
           fi
@@ -270,6 +300,9 @@ jobs:
           if [ "$PACKAGE" = "all" ] || [ "$PACKAGE" = "rust" ]; then
             check_crate sipp-sys "$VERSION"
             check_crate sipp-rs "$VERSION"
+          fi
+          if [ "$PACKAGE" = "all" ] || [ "$PACKAGE" = "swift" ]; then
+            check_swift "$VERSION"
           fi
 
           if [ "$conflicts" -eq 1 ] && [ "$DRY_RUN" != "true" ]; then
@@ -690,6 +723,50 @@ jobs:
           name: sipp-rust-crates
           path: .build/artifacts/rust/*.crate
 
+  swift:
+    name: Build Swift distribution
+    needs:
+      - gate
+      - preflight
+    if: ${{ inputs.package == 'all' || inputs.package == 'swift' }}
+    permissions:
+      contents: read
+    uses: ./.github/workflows/swift-distribution.yml
+    with:
+      artifact_name: sipp-swift-release
+      build: true
+      publish: false
+      prerelease: false
+      python_version: ${{ needs.preflight.outputs.version }}
+      source_revision: ${{ github.sha }}
+      version: ${{ needs.preflight.outputs.version }}
+
+  swift-publish:
+    name: Publish Swift distribution
+    needs:
+      - preflight
+      - web-npm
+      - node-npm
+      - python
+      - rust-source
+      - swift
+    if: ${{ inputs.dry_run == false && inputs.package == 'all' }}
+    permissions:
+      actions: read
+      contents: read
+    uses: ./.github/workflows/swift-distribution.yml
+    with:
+      artifact_name: sipp-swift-release
+      build: false
+      publish: true
+      prerelease: false
+      python_version: ${{ needs.preflight.outputs.version }}
+      source_revision: ${{ github.sha }}
+      swift_distribution_app_client_id: ${{ vars.SWIFT_DISTRIBUTION_APP_CLIENT_ID }}
+      version: ${{ needs.preflight.outputs.version }}
+    secrets:
+      swift_distribution_app_private_key: ${{ secrets.SWIFT_DISTRIBUTION_APP_PRIVATE_KEY }}
+
   publish-release:
     name: Publish public release
     runs-on: ubuntu-24.04
@@ -700,6 +777,8 @@ jobs:
       - node-npm
       - python
       - rust-source
+      - swift
+      - swift-publish
     if: ${{ inputs.dry_run == false && inputs.package == 'all' }}
     permissions:
       contents: write

--- a/.github/workflows/swift-distribution.yml
+++ b/.github/workflows/swift-distribution.yml
@@ -1,0 +1,296 @@
+name: Swift distribution
+
+on:
+  workflow_call:
+    inputs:
+      artifact_name:
+        required: true
+        type: string
+      build:
+        required: true
+        type: boolean
+      publish:
+        required: true
+        type: boolean
+      prerelease:
+        required: true
+        type: boolean
+      python_version:
+        required: true
+        type: string
+      source_revision:
+        required: true
+        type: string
+      swift_distribution_app_client_id:
+        required: false
+        type: string
+        default: ""
+      version:
+        required: true
+        type: string
+    secrets:
+      swift_distribution_app_private_key:
+        required: false
+
+permissions:
+  actions: read
+  contents: read
+
+jobs:
+  build:
+    name: Build Swift distribution
+    if: ${{ inputs.build }}
+    runs-on: macos-14
+    timeout-minutes: 240
+    steps:
+      - name: Check out Sipp
+        uses: actions/checkout@v6.0.2
+        with:
+          ref: ${{ inputs.source_revision }}
+          submodules: recursive
+
+      - name: Set up Rust with Apple targets
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-apple-darwin,x86_64-apple-darwin,aarch64-apple-ios,aarch64-apple-ios-sim,x86_64-apple-ios
+
+      - name: Set up Node
+        uses: actions/setup-node@v6.4.0
+        with:
+          node-version: 22
+
+      - name: Set up CMake and Ninja
+        uses: lukka/get-cmake@v4.3.1
+
+      - name: Cache Cargo and Swift native build outputs
+        uses: actions/cache@v5.0.5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            .build/cargo
+            .build/cmake
+            .build/c
+          key: cargo-swift-distribution-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('Cargo.lock', '.cargo/config.toml', 'crates/**/Cargo.toml', 'lib/**/Cargo.toml', 'xtask/Cargo.toml', 'bindings/**/Cargo.toml') }}
+          restore-keys: |
+            cargo-swift-distribution-${{ runner.os }}-${{ runner.arch }}-
+
+      - name: Apply package versions
+        uses: ./.github/actions/apply-package-versions
+        with:
+          npm-version: ${{ inputs.version }}
+          python-version: ${{ inputs.python_version }}
+
+      - name: Build and test Swift package
+        run: cargo xtask build swift
+
+      - name: Read Swift archive metadata
+        id: swift-metadata
+        shell: bash
+        run: |
+          set -euo pipefail
+          archive=.build/artifacts/swift/SippCore.xcframework.zip
+          checksum_file="$archive.sha256"
+          for path in "$archive" "$checksum_file"; do
+            if [ ! -f "$path" ]; then
+              echo "::error::Missing Swift distribution artifact: $path"
+              exit 1
+            fi
+          done
+          checksum="$(tr -d '\r\n' < "$checksum_file")"
+          if ! [[ "$checksum" =~ ^[0-9a-f]{64}$ ]]; then
+            echo "::error::Invalid Swift archive checksum: $checksum"
+            exit 1
+          fi
+          echo "checksum=$checksum" >> "$GITHUB_OUTPUT"
+
+      - name: Stage Swift distribution
+        shell: bash
+        env:
+          SIPP_SOURCE_REPOSITORY: noumena-labs/Sipp
+          SIPP_SOURCE_REVISION: ${{ inputs.source_revision }}
+          SWIFT_CHECKSUM: ${{ steps.swift-metadata.outputs.checksum }}
+          SWIFT_DISTRIBUTION_DIR: .build/distribution/Sipp-Swift
+          SWIFT_DISTRIBUTION_REPOSITORY: noumena-labs/Sipp-Swift
+          SWIFT_PACKAGE_SOURCE: .build/artifacts/swift/package
+          SWIFT_VERSION: ${{ inputs.version }}
+        run: node .github/scripts/swift-distribution.mjs stage
+
+      - name: Validate Swift distribution manifest
+        shell: bash
+        env:
+          DISTRIBUTION_DIR: .build/distribution/Sipp-Swift
+        run: xcrun swift package --package-path "$DISTRIBUTION_DIR" dump-package
+
+      - name: Upload Swift distribution artifact
+        uses: actions/upload-artifact@v6.0.0
+        with:
+          name: ${{ inputs.artifact_name }}
+          path: |
+            .build/artifacts/swift/SippCore.xcframework.zip
+            .build/artifacts/swift/SippCore.xcframework.zip.sha256
+            .build/distribution/Sipp-Swift/Package.swift
+            .build/distribution/Sipp-Swift/README.md
+            .build/distribution/Sipp-Swift/LICENSE
+            .build/distribution/Sipp-Swift/SIPP_SOURCE_REVISION
+            .build/distribution/Sipp-Swift/Sources
+            .build/distribution/Sipp-Swift/Tests
+          retention-days: 14
+
+      - name: Upload Swift logs on failure
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v6.0.0
+        with:
+          name: ${{ inputs.artifact_name }}-failure-logs
+          path: |
+            .build/logs
+            .build/test/run-report.json
+          if-no-files-found: ignore
+          retention-days: 14
+
+  publish:
+    name: Publish Swift distribution
+    needs: build
+    if: >-
+      ${{
+        always() &&
+        inputs.publish &&
+        (inputs.build == false || needs.build.result == 'success')
+      }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    steps:
+      - name: Check out Sipp
+        uses: actions/checkout@v6.0.2
+        with:
+          ref: ${{ inputs.source_revision }}
+          submodules: false
+
+      - name: Set up Node
+        uses: actions/setup-node@v6.4.0
+        with:
+          node-version: 22
+
+      - name: Download Swift distribution artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: ${{ inputs.artifact_name }}
+          path: .build
+
+      - name: Validate Swift publication inputs
+        id: swift-metadata
+        shell: bash
+        env:
+          ARCHIVE_PATH: .build/artifacts/swift/SippCore.xcframework.zip
+          CHECKSUM_PATH: .build/artifacts/swift/SippCore.xcframework.zip.sha256
+          DISTRIBUTION_DIR: .build/distribution/Sipp-Swift
+          SOURCE_REVISION: ${{ inputs.source_revision }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          for path in \
+            "$ARCHIVE_PATH" \
+            "$CHECKSUM_PATH" \
+            "$DISTRIBUTION_DIR/Package.swift" \
+            "$DISTRIBUTION_DIR/SIPP_SOURCE_REVISION"; do
+            if [ ! -f "$path" ]; then
+              echo "::error::Missing Swift publication input: $path"
+              exit 1
+            fi
+          done
+
+          checksum="$(tr -d '\r\n' < "$CHECKSUM_PATH")"
+          metadata_checksum="$(sed -n 's/^artifact_sha256=//p' "$DISTRIBUTION_DIR/SIPP_SOURCE_REVISION")"
+          metadata_revision="$(sed -n 's/^revision=//p' "$DISTRIBUTION_DIR/SIPP_SOURCE_REVISION")"
+          metadata_version="$(sed -n 's/^version=//p' "$DISTRIBUTION_DIR/SIPP_SOURCE_REVISION")"
+          if [ "$metadata_checksum" != "$checksum" ]; then
+            echo "::error::Swift snapshot checksum does not match $CHECKSUM_PATH."
+            exit 1
+          fi
+          if [ "$metadata_revision" != "$SOURCE_REVISION" ]; then
+            echo "::error::Swift snapshot revision $metadata_revision does not match $SOURCE_REVISION."
+            exit 1
+          fi
+          if [ "$metadata_version" != "$VERSION" ]; then
+            echo "::error::Swift snapshot version $metadata_version does not match $VERSION."
+            exit 1
+          fi
+          echo "checksum=$checksum" >> "$GITHUB_OUTPUT"
+
+      - name: Create Sipp-Swift installation token
+        id: swift-app
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ inputs.swift_distribution_app_client_id }}
+          private-key: ${{ secrets.swift_distribution_app_private_key }}
+          owner: noumena-labs
+          repositories: Sipp-Swift
+          permission-contents: write
+
+      - name: Check out Sipp-Swift
+        uses: actions/checkout@v6.0.2
+        with:
+          repository: noumena-labs/Sipp-Swift
+          token: ${{ steps.swift-app.outputs.token }}
+          path: .build/swift-publish/Sipp-Swift
+          ref: main
+          fetch-depth: 0
+
+      - name: Sync Sipp-Swift snapshot
+        shell: bash
+        env:
+          SWIFT_DISTRIBUTION_DIR: .build/swift-publish/Sipp-Swift
+          SWIFT_DISTRIBUTION_SOURCE: .build/distribution/Sipp-Swift
+        run: node .github/scripts/swift-distribution.mjs sync
+
+      - name: Commit and tag Sipp-Swift snapshot
+        shell: bash
+        working-directory: .build/swift-publish/Sipp-Swift
+        env:
+          SOURCE_REVISION: ${{ inputs.source_revision }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          remote_tag_sha="$(git ls-remote --tags --refs origin "refs/tags/$VERSION" | awk '{ print $1 }' || true)"
+          if [ -n "$remote_tag_sha" ]; then
+            git fetch origin "refs/tags/$VERSION:refs/tags/$VERSION"
+            expected_metadata="$(cat SIPP_SOURCE_REVISION)"
+            published_metadata="$(git show "$VERSION:SIPP_SOURCE_REVISION")"
+            if [ "$published_metadata" != "$expected_metadata" ]; then
+              echo "::error::Sipp-Swift $VERSION already exists with different source metadata."
+              exit 1
+            fi
+            echo "Sipp-Swift $VERSION already represents $SOURCE_REVISION; reusing it."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add -A
+          if git diff --cached --quiet; then
+            echo "Sipp-Swift main already contains the generated $VERSION snapshot."
+          else
+            git commit -m "Sync Sipp $VERSION from $SOURCE_REVISION"
+          fi
+          git tag "$VERSION"
+          git push --atomic origin HEAD:main "refs/tags/$VERSION"
+
+      - name: Publish Sipp-Swift release
+        uses: softprops/action-gh-release@v3
+        with:
+          repository: noumena-labs/Sipp-Swift
+          token: ${{ steps.swift-app.outputs.token }}
+          tag_name: ${{ inputs.version }}
+          name: Sipp Swift ${{ inputs.version }}
+          draft: false
+          prerelease: ${{ inputs.prerelease }}
+          generate_release_notes: false
+          fail_on_unmatched_files: true
+          overwrite_files: true
+          body: |
+            CI-generated Swift distribution from noumena-labs/Sipp@${{ inputs.source_revision }}.
+
+            Archive SHA-256: `${{ steps.swift-metadata.outputs.checksum }}`
+          files: |
+            .build/artifacts/swift/SippCore.xcframework.zip
+            .build/artifacts/swift/SippCore.xcframework.zip.sha256

--- a/.github/workflows/swift-distribution.yml
+++ b/.github/workflows/swift-distribution.yml
@@ -81,7 +81,7 @@ jobs:
           npm-version: ${{ inputs.version }}
           python-version: ${{ inputs.python_version }}
 
-      - name: Build and test Swift package
+      - name: Build Swift distribution
         run: cargo xtask build swift
 
       - name: Read Swift archive metadata

--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ await client.close();
 ### 3. Swift Quick Start (Native macOS and iOS)
 
 Swift support requires macOS and Xcode. The build stages a local Swift package
-at `.build/artifacts/swift/package` and builds the macOS and iOS examples.
+at `.build/artifacts/swift/package` for macOS and iOS.
 
 ```bash
 sipp toolchain install rust-apple
@@ -270,9 +270,11 @@ print(response.text)
 ```
 
 Run the staged command-line example, open the sandboxed macOS app, or launch
-the iOS example in a simulator:
+the iOS example in a simulator. Build the optional example artifacts first:
 
 ```bash
+sipp build swift --examples
+
 .build/artifacts/swift/examples/SippCLI chat \
   /path/to/model.gguf "Explain on-device inference"
 

--- a/docs/en/examples-demos.md
+++ b/docs/en/examples-demos.md
@@ -19,7 +19,7 @@ Start with:
 ```bash
 cargo xtask run examples gateway rust --case query
 cargo xtask run examples serve browser
-cargo xtask build swift
+cargo xtask build swift --examples
 cargo xtask run examples ios --simulator SIMULATOR-UDID
 ```
 

--- a/docs/en/maintainers/README.md
+++ b/docs/en/maintainers/README.md
@@ -10,7 +10,7 @@ Application developers who only need the published packages should start with
 ## Start Here
 
 - [Source Builds](source-builds.md) covers checkout setup, `sipp`, source
-  examples, demos, and package build targets.
+  examples, demos, package build targets, and Swift distribution.
 - [Architecture](../architecture.md) explains crate and package boundaries.
 - [Gateway Architecture](../gateway/architecture.md) explains gateway
   layering.

--- a/docs/en/maintainers/source-builds.md
+++ b/docs/en/maintainers/source-builds.md
@@ -44,24 +44,29 @@ build selector or runtime fallback. The build also creates the macOS
 command-line example and the ad-hoc-signed sandboxed SwiftUI app under
 `.build/artifacts/swift`.
 
-## Swift Distribution Boundary
+## Swift Distribution
 
-The local staged package contains generated UniFFI Swift source and a local
-binary-target path. Those generated sources are intentionally absent from this
-repository, so a Sipp monorepo tag is not itself a consumable SwiftPM package.
+[`noumena-labs/Sipp-Swift`](https://github.com/noumena-labs/Sipp-Swift) is the
+CI-generated Swift Package Manager distribution for Sipp. It is a delivery
+repository, not a second development repository, and its generated package
+files must not be edited manually.
 
-Publish the staged package through a dedicated Swift distribution repository.
-That repository owns one explicit `Package.swift` whose binary target uses the
-versioned GitHub release URL and checksum produced by `sipp build swift`. Copy
-the staged public and generated sources into the distribution repository,
-replace the local binary target with that remote declaration, test a clean
-consumer, and tag the distribution commit with the same version.
+Sipp is the only source of truth. Swift sources and tests live under
+`lib/swift`, Rust and UniFFI binding sources live under `bindings/swift`, and
+`xtask` owns XCFramework assembly and package validation. The main CI workflow
+tests the Swift package without publishing. Dev and stable release workflows
+build and validate the XCFramework, stage the package, record the exact source
+revision, and push the generated snapshot to `Sipp-Swift`.
 
-Do not commit a placeholder checksum, read release metadata from environment
-variables in `Package.swift`, or add an alternate local/remote target branch.
-The manifest must contain the exact URL and checksum for one published archive.
-Creating and publishing the external distribution repository is a release
-operation and is not performed by xtask.
+Sipp tags are the sole version authority. A dev version such as `0.1.4-dev1`
+produces the Swift tag `0.1.4-dev1`, while a stable version such as `0.1.4`
+produces `0.1.4`. Existing Swift tags are checked only to make retries
+idempotent and prevent replacement of an immutable release.
+
+The XCFramework archive is stored as a GitHub release asset rather than
+committed to Git. The generated `Package.swift` points its binary target to the
+versioned archive and checksum, allowing consumers to use Sipp as a normal
+SwiftPM dependency.
 
 CUDA builds compile a portable cloud GPU architecture list by default. Set
 `SIPP_CUDA_ARCHITECTURES` (semicolon-separated CMake entries, for example

--- a/docs/en/maintainers/source-builds.md
+++ b/docs/en/maintainers/source-builds.md
@@ -40,9 +40,10 @@ Use `--backend vulkan`, `--backend cuda`, `--backend metal`, or
 The Swift target requires macOS and Xcode. It produces one XCFramework for
 macOS and iOS. macOS arm64 and iOS device arm64 use Metal; macOS x86_64 and
 iOS Simulator arm64/x86_64 use CPU. The backend is fixed per slice, with no
-build selector or runtime fallback. The build also creates the macOS
-command-line example and the ad-hoc-signed sandboxed SwiftUI app under
-`.build/artifacts/swift`.
+build selector or runtime fallback. The build validates the staged package for
+macOS, iOS, and iOS Simulator, then creates the distribution archive and
+checksum. Add `--examples` only when local CLI, SwiftUI, and iOS example
+artifacts are needed.
 
 ## Swift Distribution
 
@@ -54,9 +55,11 @@ files must not be edited manually.
 Sipp is the only source of truth. Swift sources and tests live under
 `lib/swift`, Rust and UniFFI binding sources live under `bindings/swift`, and
 `xtask` owns XCFramework assembly and package validation. The main CI workflow
-tests the Swift package without publishing. Dev and stable release workflows
-build and validate the XCFramework, stage the package, record the exact source
-revision, and push the generated snapshot to `Sipp-Swift`.
+builds only the current macOS host slice needed to run the Swift unit tests.
+Dev and stable release workflows build every macOS, iOS device, and iOS
+Simulator slice required by consumers; validate the staged package on all three
+platform families; record the exact source revision; and push the generated
+snapshot to `Sipp-Swift`.
 
 Sipp tags are the sole version authority. A dev version such as `0.1.4-dev1`
 produces the Swift tag `0.1.4-dev1`, while a stable version such as `0.1.4`

--- a/docs/en/packages/swift.md
+++ b/docs/en/packages/swift.md
@@ -181,10 +181,12 @@ sources.
 
 ## Examples
 
-`cargo xtask build swift` builds a command-line example and a sandboxed SwiftUI
-example for macOS, plus a SwiftUI iOS example:
+Build the optional command-line, sandboxed macOS SwiftUI, and iOS SwiftUI
+examples explicitly:
 
 ```bash
+cargo xtask build swift --examples
+
 .build/artifacts/swift/examples/SippCLI chat /path/to/model.gguf \
   "Explain on-device inference"
 open .build/artifacts/swift/examples/SippSandbox.app

--- a/docs/en/sipp/commands.md
+++ b/docs/en/sipp/commands.md
@@ -39,9 +39,10 @@ does not build every backend variant for every package.
 `build swift` runs on macOS and creates one `SippCore.xcframework` for macOS
 and iOS. Its macOS arm64 and iOS device arm64 slices use Metal; its macOS
 x86_64 and iOS Simulator arm64/x86_64 slices use CPU. There is no Swift backend
-option or runtime fallback. The command stages the local package, runs its
-tests, builds the macOS examples, and assembles an ad-hoc-signed SwiftUI app
-under `.build/artifacts/swift`.
+option or runtime fallback. The command stages the local package, validates it
+for macOS, iOS, and iOS Simulator, and creates the distribution archive and
+checksum under `.build/artifacts/swift`. Add `--examples` to build the local
+CLI, SwiftUI, and iOS examples as well.
 
 Backend values:
 

--- a/docs/en/testing.md
+++ b/docs/en/testing.md
@@ -59,7 +59,7 @@ Unit suite names expose suite-specific options, such as
 | `cargo xtask test unit suite cli` | CLI black-box integration tests | `apps/cli/tests` |
 | `cargo xtask test unit suite node-package` | Deterministic Node package API tests | `lib/node`, `bindings/node` |
 | `cargo xtask test unit suite python-package` | Deterministic Python package API tests | `lib/python`, `bindings/python` |
-| `cargo xtask test unit suite swift-package` | Swift package, examples, XCFramework, ABI, linkage, signing, and distribution checks | `lib/swift`, `bindings/swift`, `examples/swift` |
+| `cargo xtask test unit suite swift-package` | Host macOS slice and staged Swift package unit tests | `lib/swift`, `bindings/swift` |
 
 ## Unit Groups
 
@@ -75,8 +75,9 @@ bundled browser package. Release package builds use `cargo xtask build wasm`,
 which stages the pthread WebGPU+JSPI and pthread CPU non-JSPI artifacts.
 
 The `swift-package` suite is macOS-only and deliberately fails its host gate on
-other platforms. It runs the complete staged-package and artifact-validation
-pipeline rather than substituting host-free checks for Apple toolchain work.
+other platforms. It builds only the current macOS host slice needed to stage
+the package and run `swift test`. Multi-platform XCFramework and distribution
+validation belongs to `cargo xtask build swift` in dev and release workflows.
 
 `test smoke` owns holistic integration checks. It is split into explicit
 namespaces:

--- a/docs/zh/examples-demos.md
+++ b/docs/zh/examples-demos.md
@@ -7,6 +7,7 @@
 - `examples/rust`：Rust 的 query、chat、embed、视觉、网关及服务商示例。
 - `examples/node`：Node.js 的 query、chat、embed、视觉及网关示例。
 - `examples/python`：Python 的 query、chat、embed、视觉及网关示例。
+- `examples/swift`：macOS 命令行、macOS SwiftUI 和 iOS SwiftUI 客户端。
 - `examples/web`：用于验证本地和网关工作流的 Vite 浏览器页面。
 - `examples/gateway`：极简的 Axum 网关路由配置。
 
@@ -15,6 +16,8 @@
 ```bash
 cargo xtask run examples gateway rust --case query
 cargo xtask run examples serve browser
+cargo xtask build swift --examples
+cargo xtask run examples ios --simulator SIMULATOR-UDID
 ```
 
 ## 演示

--- a/docs/zh/maintainers/README.md
+++ b/docs/zh/maintainers/README.md
@@ -6,7 +6,7 @@
 
 ## 目录与指引
 
-- [源码构建](source-builds.md)：环境引导、`sipp` 命令使用、运行源码示例和演示程序、编译各包目标产物。
+- [源码构建](source-builds.md)：环境引导、`sipp` 命令使用、运行源码示例和演示程序、编译各包目标产物及 Swift 分发。
 - [架构](../architecture.md)：Crate 边界划分与包组织结构。
 - [网关架构](../gateway/architecture.md)：网关系统分层设计。
 - [测试](../testing.md)：内建的所有测试套件。

--- a/docs/zh/maintainers/source-builds.md
+++ b/docs/zh/maintainers/source-builds.md
@@ -32,8 +32,9 @@ sipp build all
 
 Swift 目标要求使用 macOS 和 Xcode，并为 macOS 与 iOS 生成一个
 XCFramework。macOS arm64 和 iOS 设备 arm64 使用 Metal，macOS x86_64
-以及 iOS 模拟器 arm64/x86_64 使用 CPU。各切片的后端固定，不提供构建选择器或运行时回退。构建还会在
-`.build/artifacts/swift` 下生成 macOS 命令行示例和经过临时签名的沙盒 SwiftUI 应用。
+以及 iOS 模拟器 arm64/x86_64 使用 CPU。各切片的后端固定，不提供构建选择器或运行时回退。构建会验证暂存包能否用于
+macOS、iOS 和 iOS 模拟器，然后生成分发压缩包及其校验和。仅在需要本地 CLI、SwiftUI 和 iOS 示例产物时添加
+`--examples`。
 
 ## Swift 分发
 
@@ -42,9 +43,8 @@ Sipp 由 CI 生成的 Swift Package Manager 分发仓库。它只负责交付，
 
 Sipp 是唯一的源码和版本来源。Swift 源码与测试位于 `lib/swift`，Rust
 和 UniFFI 绑定源码位于 `bindings/swift`，XCFramework 组装与包验证由
-`xtask` 管理。主 CI 工作流只测试 Swift 包，不执行发布。开发版与稳定版发布工作流会构建并验证
-XCFramework、暂存 Swift 包、记录准确的源码修订版本，再将生成的快照推送到
-`Sipp-Swift`。
+`xtask` 管理。主 CI 工作流只构建运行 Swift 单元测试所需的当前 macOS 主机切片，不执行发布。开发版与稳定版发布工作流会构建使用者需要的所有
+macOS、iOS 设备和 iOS 模拟器切片，在三个平台系列上验证暂存包，记录准确的源码修订版本，再将生成的快照推送到 `Sipp-Swift`。
 
 版本完全由 Sipp 标签决定。例如，开发版 `0.1.4-dev1` 对应 Swift 标签
 `0.1.4-dev1`，稳定版 `0.1.4` 对应 Swift 标签 `0.1.4`。工作流仅在发布时检查已有 Swift 标签，以便安全重试并防止覆盖不可变的发布版本。

--- a/docs/zh/maintainers/source-builds.md
+++ b/docs/zh/maintainers/source-builds.md
@@ -22,12 +22,35 @@ Windows 上在 PowerShell 中执行 `.\setup.ps1`，或在 CMD 中执行 `setup.
 sipp build core
 sipp build node --backend cpu
 sipp build python --backend cpu
+sipp build swift
 sipp build gateway-server --backend cpu
 sipp build wasm
 sipp build all
 ```
 
 支持硬件加速的原生目标可使用 `--backend vulkan`、`--backend cuda`、`--backend metal` 或 `--backend all` 等参数。
+
+Swift 目标要求使用 macOS 和 Xcode，并为 macOS 与 iOS 生成一个
+XCFramework。macOS arm64 和 iOS 设备 arm64 使用 Metal，macOS x86_64
+以及 iOS 模拟器 arm64/x86_64 使用 CPU。各切片的后端固定，不提供构建选择器或运行时回退。构建还会在
+`.build/artifacts/swift` 下生成 macOS 命令行示例和经过临时签名的沙盒 SwiftUI 应用。
+
+## Swift 分发
+
+[`noumena-labs/Sipp-Swift`](https://github.com/noumena-labs/Sipp-Swift) 是
+Sipp 由 CI 生成的 Swift Package Manager 分发仓库。它只负责交付，并非第二个开发仓库；请勿手动修改其中由 CI 生成的包文件。
+
+Sipp 是唯一的源码和版本来源。Swift 源码与测试位于 `lib/swift`，Rust
+和 UniFFI 绑定源码位于 `bindings/swift`，XCFramework 组装与包验证由
+`xtask` 管理。主 CI 工作流只测试 Swift 包，不执行发布。开发版与稳定版发布工作流会构建并验证
+XCFramework、暂存 Swift 包、记录准确的源码修订版本，再将生成的快照推送到
+`Sipp-Swift`。
+
+版本完全由 Sipp 标签决定。例如，开发版 `0.1.4-dev1` 对应 Swift 标签
+`0.1.4-dev1`，稳定版 `0.1.4` 对应 Swift 标签 `0.1.4`。工作流仅在发布时检查已有 Swift 标签，以便安全重试并防止覆盖不可变的发布版本。
+
+XCFramework 压缩包作为 GitHub Release 资产存储，不提交到 Git。生成的
+`Package.swift` 会让二进制目标指向带版本的压缩包及其校验和，因此使用者可以将 Sipp 作为普通 SwiftPM 依赖引入。
 
 默认情况下，CUDA 会编译一系列相关 GPU 架构的产物。为加快本地编译速度，可在构建前设置 `SIPP_CUDA_ARCHITECTURES` 环境变量（使用分号分隔的 CMake 架构字符串，例如仅针对 A100 设置 `80`）。完整架构列表见[网关 Docker](../gateway/docker.md)。
 

--- a/docs/zh/sipp/commands.md
+++ b/docs/zh/sipp/commands.md
@@ -21,12 +21,15 @@ sipp build core
 sipp build wasm
 sipp build node --backend cpu
 sipp build python --backend vulkan
+sipp build swift
 sipp build cli --backend all
 sipp build gateway-server --backend cpu
 sipp build all
 ```
 
 `build all` 构建所有主要目标，默认生成 CPU 原生输出，不为每个包构建所有后端变体。
+
+`build swift` 只能在 macOS 上运行。它会生成 macOS、iOS 设备和 iOS 模拟器所需的 XCFramework 切片，验证暂存包，并在 `.build/artifacts/swift` 下创建分发压缩包与校验和。仅在需要本地 CLI、SwiftUI 和 iOS 示例产物时添加 `--examples`。
 
 支持的后端：
 

--- a/docs/zh/testing.md
+++ b/docs/zh/testing.md
@@ -25,6 +25,7 @@ cargo xtask test unit suite browser-package
 cargo xtask test unit suite demos
 cargo xtask test unit suite node-package --backend cpu
 cargo xtask test unit suite python-package --backend cpu
+cargo xtask test unit suite swift-package
 cargo xtask test smoke suite example-node --backend cpu
 cargo xtask test smoke suite example-gateway --backend cpu --case query
 cargo xtask test smoke suite playground-browser
@@ -48,21 +49,24 @@ cargo xtask test verify --changed
 | --- | --- | --- |
 | `cargo xtask test unit suite xtask` | xtask 工具及编排逻辑测试 | `xtask/src/tests` |
 | `cargo xtask test unit suite rust-crates` | 工作区 Crate 的单元测试 | `crates`, `lib/gateway`, `apps` |
-| `cargo xtask test unit suite rust-bindings` | Rust 绑定 Crate 的单元测试 | `bindings/node`, `bindings/python`, `bindings/wasm` |
+| `cargo xtask test unit suite rust-bindings` | Rust 绑定 Crate 的单元测试 | `bindings/swift`, `bindings/wasm` |
 | `cargo xtask test unit suite browser-package` | 浏览器包 TypeScript 测试 | `lib/web/tests` |
 | `cargo xtask test unit suite demos` | 浏览器端演示项目的 TypeScript 测试 | `demos` |
 | `cargo xtask test unit suite api` | 库级别公共 API 集成测试 | `crates/sipp/tests` |
 | `cargo xtask test unit suite cli` | CLI 的黑盒集成测试 | `apps/cli/tests` |
 | `cargo xtask test unit suite node-package` | Node 库的确定性 API 测试 | `lib/node`, `bindings/node` |
 | `cargo xtask test unit suite python-package` | Python 库的确定性 API 测试 | `lib/python`, `bindings/python` |
+| `cargo xtask test unit suite swift-package` | macOS 主机切片与暂存 Swift 包单元测试 | `lib/swift`, `bindings/swift` |
 
 ## 单元测试组
 
 | 命令 | 包含的套件 |
 | --- | --- |
 | `cargo xtask test unit group whitebox` | `xtask`、`rust-crates`、`rust-bindings`、`browser-package`、`demos` |
-| `cargo xtask test unit group interface` | `api`、`cli`、`node-package`、`python-package` |
+| `cargo xtask test unit group interface` | `api`、`cli`、`node-package`、`python-package`、`swift-package` |
 | `cargo xtask test unit group full` | 所有确定性单元测试套件 |
+
+`swift-package` 套件只能在 macOS 上运行。它只构建暂存包和执行 `swift test` 所需的当前 macOS 主机切片。开发版与稳定版工作流通过 `cargo xtask build swift` 负责多平台 XCFramework 和分发验证。
 
 `test smoke` 用于端到端集成验证，同样有明确的命名空间分类：
 

--- a/examples/swift/README.md
+++ b/examples/swift/README.md
@@ -1,11 +1,11 @@
 # Swift Examples
 
 The Swift examples consume only the public `Sipp` product from the staged
-Swift package. Build the XCFramework, package, examples, and signed sandbox app
-on macOS:
+Swift package. Build the XCFramework, package, optional examples, and signed
+sandbox app on macOS:
 
 ```bash
-cargo xtask build swift
+cargo xtask build swift --examples
 ```
 
 The package contains a Metal arm64 macOS slice and a CPU x86_64 macOS slice.

--- a/lib/swift/Distribution/README.md
+++ b/lib/swift/Distribution/README.md
@@ -1,0 +1,38 @@
+# Sipp for Swift
+
+This repository is the generated Swift Package Manager distribution channel
+for [Sipp](https://github.com/noumena-labs/Sipp). Do not edit the package
+sources here: each tagged snapshot is produced and tested by Sipp's release
+workflow from one recorded source commit.
+
+## Add The Package
+
+In Xcode, select **File → Add Package Dependencies**, then enter:
+
+```text
+https://github.com/noumena-labs/Sipp-Swift.git
+```
+
+Select a tagged release and add the `Sipp` product to the macOS or iOS target.
+For a `Package.swift` dependency, use the same URL and the desired tagged
+version.
+
+```swift
+import Sipp
+
+let client = try SippClient()
+```
+
+The package downloads a versioned `SippCore.xcframework.zip` release asset and
+verifies the checksum committed in `Package.swift`. It does not require Rust,
+CMake, or a Sipp source checkout.
+
+Development prereleases are intended for integration testing and should be
+pinned to an exact version. Stable releases follow Sipp's shared package
+version.
+
+## Source And Issues
+
+`SIPP_SOURCE_REVISION` records the Sipp repository commit, package version, and
+binary checksum used for the current snapshot. Report issues and contribute
+changes in the [Sipp repository](https://github.com/noumena-labs/Sipp).

--- a/lib/swift/README.md
+++ b/lib/swift/README.md
@@ -11,32 +11,28 @@ polling stays on the calling async task. The public target adds Swift semantics:
 Foundation URLs, Application Support storage, Swift values and errors,
 `AsyncSequence` token batches, cached terminal responses, task cancellation,
 and persistent security-scoped model-file access.
-Build and test the staged package with:
+Build the distribution package or run the host-only unit tests with:
 
 ```bash
 cargo xtask build swift
-# Equivalent cataloged interface gate:
 cargo xtask test unit suite swift-package
 ```
 
-The command writes a complete local package to
-`.build/artifacts/swift/package`. The artifact directory also contains the
-external consumer fixture, `SippCore.abi.txt`, the distributable
-`SippCore.xcframework.zip`, and its `.sha256` checksum. The source directory
-intentionally does not commit generated bindings or native build artifacts.
-The same gate builds `.build/artifacts/swift/examples/SippCLI`, assembles
-`.build/artifacts/swift/examples/SippSandbox.app`, and ad hoc signs the app
-with the committed App Sandbox entitlement.
+The build command writes a complete local package to
+`.build/artifacts/swift/package`. The artifact directory also contains
+`SippCore.abi.txt`, the distributable `SippCore.xcframework.zip`, and its
+`.sha256` checksum. Add `--examples` to build the local CLI, SwiftUI, and iOS
+example artifacts. The source directory intentionally does not commit generated
+bindings or native build artifacts.
 
 The XCFramework contains Metal slices for macOS arm64 and iOS device arm64,
 plus CPU slices for macOS x86_64 and both iOS Simulator architectures. There is
-no runtime backend selection or fallback. The build fails unless both generated
-binding passes are byte-identical, each native slice and universal archive
-contain exactly their declared architectures, the generated and exported Sipp
-FFI symbol sets match exactly, the external consumer links only Apple system and
-Swift runtime libraries, and SwiftPM's archive checksum matches an independent
-SHA-256 calculation. `cargo xtask clean` removes all of these generated outputs
-through the shared artifact root.
+no runtime backend selection or fallback. The build fails unless each native
+slice and universal archive contains exactly its declared architectures, the
+generated and exported Sipp FFI symbol sets match exactly, the staged package
+builds for macOS, iOS, and iOS Simulator, and SwiftPM's archive checksum matches
+an independent SHA-256 calculation. `cargo xtask clean` removes all generated
+outputs through the shared artifact root.
 
 The public API is:
 
@@ -63,9 +59,9 @@ Sandbox-owned model files are registered as zero-copy paths relative to the
 application container, so a container relocation does not invalidate them.
 External files use versioned security-scoped bookmarks stored beside the native
 model registry; Sipp resolves a model's bookmarks only when that model is
-activated and then retains access until successful model removal. The signed
-sandbox relaunch test still requires macOS and must pass before release. The
-complete gates are tracked in the [Swift package plan](../../docs/en/packages/swift.md).
+activated and then retains access until successful model removal. The complete
+package behavior is documented in the
+[Swift package guide](../../docs/en/packages/swift.md).
 
 Runnable command-line and SwiftUI examples live under
 [`examples/swift`](../../examples/swift/README.md). Remote SwiftPM installation

--- a/xtask/src/cli.rs
+++ b/xtask/src/cli.rs
@@ -478,12 +478,13 @@ supported by the host operating system.")]
     /// Build the Apple Swift package.
     #[command(long_about = "\
 Build the macOS arm64 and x86_64 UniFFI static libraries, merge them into a
-universal archive, create SippCore.xcframework, and test the staged SwiftPM
-package.
+universal archive, build the iOS device and Simulator slices, validate the
+staged SwiftPM package on each supported platform, and create the distribution
+archive.
 
 This target requires macOS, Xcode, the managed Rust Apple targets, and
 initialized git submodules.")]
-    Swift,
+    Swift(SwiftBuildArgs),
 
     /// Build the Rust CLI distribution directory.
     #[command(long_about = "\
@@ -517,6 +518,14 @@ artifact contains sipp-gateway, base runtime libraries, and selected ggml
 backend plugins in .build/artifacts/gateway-server.")]
     #[command(after_long_help = BACKEND_HELP)]
     GatewayServer(BackendArgs),
+}
+
+/// Options for building the Apple Swift package.
+#[derive(Args, Default)]
+pub struct SwiftBuildArgs {
+    /// Also build the local CLI, SwiftUI, and iOS examples.
+    #[arg(long)]
+    pub examples: bool,
 }
 
 /// Developer run workflows.
@@ -1146,7 +1155,7 @@ pub enum TestSuiteId {
     NodePackage,
     /// Python package interface tests.
     PythonPackage,
-    /// Apple Swift package interface and artifact tests.
+    /// Apple Swift package unit tests.
     SwiftPackage,
     /// CLI local generation smoke tests.
     CliSmoke,

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -120,7 +120,10 @@ fn build_summary(target: &BuildCommands) -> String {
         BuildCommands::Node(args) => {
             format!("Build Node.js bindings ({})", backend_summary(args.backend))
         }
-        BuildCommands::Swift => "Build Apple Swift package".to_owned(),
+        BuildCommands::Swift(args) if args.examples => {
+            "Build Apple Swift package and examples".to_owned()
+        }
+        BuildCommands::Swift(_) => "Build Apple Swift package".to_owned(),
         BuildCommands::Cli(args) => {
             format!(
                 "Build Rust CLI distribution ({})",
@@ -162,7 +165,7 @@ fn run_build(target: BuildCommands, sh: &Shell, ctx: &BuildContext) -> Result<()
         BuildCommands::Wasm(args) => targets::wasm::build(sh, ctx, args.threading, args.runtime)?,
         BuildCommands::Python(args) => targets::python::build(sh, ctx, args.backend.as_ref())?,
         BuildCommands::Node(args) => targets::node::build(sh, ctx, args.backend.as_ref())?,
-        BuildCommands::Swift => targets::swift::build(sh, ctx)?,
+        BuildCommands::Swift(args) => targets::swift::build(sh, ctx, args.examples)?,
         BuildCommands::Cli(args) => targets::cli::build(sh, ctx, args.backend.as_ref())?,
         BuildCommands::GatewayServer(args) => {
             targets::gateway_server::build(sh, ctx, args.backend.as_ref())?

--- a/xtask/src/run.rs
+++ b/xtask/src/run.rs
@@ -69,7 +69,7 @@ fn run_examples(sh: &Shell, ctx: &BuildContext, command: RunExamplesCommands) ->
 
 fn run_ios_example(sh: &Shell, ctx: &BuildContext, args: &RunIosExampleArgs) -> Result<()> {
     if !args.no_build {
-        targets::swift::build(sh, ctx)?;
+        targets::swift::build(sh, ctx, true)?;
     }
 
     let app = targets::swift::ios_example_app(ctx);

--- a/xtask/src/targets/swift.rs
+++ b/xtask/src/targets/swift.rs
@@ -31,7 +31,7 @@ const SWIFT_XCFRAMEWORK_NAME: &str = "SippCore.xcframework";
 const SWIFT_DISTRIBUTION_ARCHIVE: &str = "SippCore.xcframework.zip";
 const SWIFT_DISTRIBUTION_CHECKSUM: &str = "SippCore.xcframework.zip.sha256";
 const SWIFT_ABI_MANIFEST: &str = "SippCore.abi.txt";
-const SWIFT_CONSUMER_NAME: &str = "SippConsumer";
+const SWIFT_PACKAGE_SCHEME: &str = "Sipp";
 const SWIFT_CLI_NAME: &str = "SippCLI";
 const SWIFT_SANDBOX_NAME: &str = "SippSandbox";
 const SWIFT_IOS_APP_NAME: &str = "SippIOS";
@@ -39,6 +39,11 @@ const SWIFT_IOS_APP_NAME: &str = "SippIOS";
 pub(crate) const SWIFT_IOS_APP_BUNDLE_ID: &str = "ai.sipp.examples.ios";
 const SWIFT_MACOS_DEPLOYMENT_TARGET: &str = "11.0";
 const SWIFT_IOS_DEPLOYMENT_TARGET: &str = "16.0";
+const SWIFT_PACKAGE_DESTINATIONS: [(&str, &str); 3] = [
+    ("macos", "generic/platform=macOS"),
+    ("ios", "generic/platform=iOS"),
+    ("ios-simulator", "generic/platform=iOS Simulator"),
+];
 pub(crate) const XCRUN_PATH: &str = "/usr/bin/xcrun";
 pub(crate) const DITTO_PATH: &str = "/usr/bin/ditto";
 pub(crate) const CODESIGN_PATH: &str = "/usr/bin/codesign";
@@ -89,14 +94,17 @@ const IOS_SIMULATOR_X86_64: AppleSlice = AppleSlice {
     deployment_target: SWIFT_IOS_DEPLOYMENT_TARGET,
 };
 
-/// Builds and validates the staged Apple Swift package and macOS examples.
-pub fn build(sh: &Shell, ctx: &BuildContext) -> Result<()> {
+/// Builds and validates the distributable Apple Swift package.
+pub fn build(sh: &Shell, ctx: &BuildContext, examples: bool) -> Result<()> {
     ensure_macos_host()?;
     ensure_swift_sources(ctx)?;
+    if examples {
+        ensure_swift_example_sources(ctx)?;
+    }
 
     let started_at = Instant::now();
     let artifacts_dir = ctx.swift_artifacts_dir();
-    output::phase("Swift bindings");
+    output::phase("Swift distribution");
     output::path("Binding workspace", &ctx.bindings_swift_dir());
     output::path("Package source", &ctx.swift_package_dir());
     output::path("Artifact directory", &artifacts_dir);
@@ -112,9 +120,6 @@ pub fn build(sh: &Shell, ctx: &BuildContext) -> Result<()> {
     let ios_simulator_x86_64 = build_archive(sh, ctx, &target_dir, IOS_SIMULATOR_X86_64)?;
     let generated_dir = staging_dir.join("generated");
     generate_bindings(sh, ctx, &macos_arm64, &generated_dir)?;
-    let generated_check_dir = staging_dir.join("generated-check");
-    generate_bindings(sh, ctx, &macos_arm64, &generated_check_dir)?;
-    validate_identical_directories(&generated_dir, &generated_check_dir)?;
 
     let macos_archive =
         create_universal_archive(sh, &staging_dir.join("macos"), &macos_arm64, &macos_x86_64)?;
@@ -147,72 +152,83 @@ pub fn build(sh: &Shell, ctx: &BuildContext) -> Result<()> {
     let package_dir = stage_package(sh, ctx, &generated_dir)?;
     let xcframework = package_dir.join("Binary").join(SWIFT_XCFRAMEWORK_NAME);
     let headers_dir = generated_dir.join("Headers");
-    output::run_build_command(
-        "Creating SippCore.xcframework",
-        cmd!(
-            sh,
-            "{XCRUN_PATH} xcodebuild -create-xcframework -library {macos_archive} -headers {headers_dir} -library {ios_arm64} -headers {headers_dir} -library {ios_simulator_archive} -headers {headers_dir} -output {xcframework}"
-        ),
-    )
-    .context("failed to create SippCore.xcframework")?;
-
-    {
-        let _dir = sh.push_dir(&package_dir);
-        output::run_build_command(
-            "Testing staged Swift package",
-            cmd!(sh, "{XCRUN_PATH} swift test"),
-        )
-        .context("staged Swift package tests failed")?;
-    }
-    let consumer_dir = artifacts_dir.join("consumer");
-    copy_dir_recursive(&ctx.swift_package_dir().join("Consumer"), &consumer_dir)?;
-    let consumer_executable =
-        build_swift_executable_package(sh, &consumer_dir, SWIFT_CONSUMER_NAME)?;
-    output::run_test_command(
-        "Running clean Swift package consumer",
-        cmd!(sh, "{consumer_executable}"),
-    )
-    .context("clean Swift package consumer failed")?;
-    validate_dynamic_linkage(sh, &consumer_executable)?;
-
-    let examples_source = ctx.workspace_root().join("examples/swift");
-    let examples_dir = artifacts_dir.join("examples");
-    let cli_dir = examples_dir.join("cli");
-    copy_dir_recursive(&examples_source.join("cli"), &cli_dir)?;
-    let built_cli = build_swift_executable_package(sh, &cli_dir, SWIFT_CLI_NAME)?;
-    let cli_executable = examples_dir.join(SWIFT_CLI_NAME);
-    fs::copy(&built_cli, &cli_executable).with_context(|| {
-        format!(
-            "failed to stage Swift CLI from {} to {}",
-            built_cli.display(),
-            cli_executable.display()
-        )
-    })?;
-    validate_dynamic_linkage(sh, &cli_executable)?;
-
-    let swiftui_dir = examples_dir.join("swiftui");
-    copy_dir_recursive(&examples_source.join("swiftui"), &swiftui_dir)?;
-    let swiftui_executable = build_swift_executable_package(sh, &swiftui_dir, SWIFT_SANDBOX_NAME)?;
-    validate_dynamic_linkage(sh, &swiftui_executable)?;
-    let sandbox_app =
-        bundle_and_sign_sandbox_app(sh, &swiftui_dir, &swiftui_executable, &examples_dir)?;
-    let ios_app = build_ios_example(sh, ctx)?;
+    create_xcframework(
+        sh,
+        &xcframework,
+        &headers_dir,
+        &[&macos_archive, &ios_arm64, &ios_simulator_archive],
+    )?;
+    validate_package_platforms(sh, ctx, &package_dir)?;
 
     let (distribution_archive, distribution_checksum) =
         archive_distribution(sh, ctx, &xcframework)?;
+
+    if examples {
+        build_examples(sh, ctx)?;
+    }
 
     output::artifact(&xcframework);
     output::artifact(&abi_manifest);
     output::artifact(&distribution_archive);
     output::artifact(&distribution_checksum);
-    output::artifact(&cli_executable);
-    output::artifact(&sandbox_app);
-    output::artifact(&ios_app);
     output::success(format!(
         "Swift build complete in {}",
         output::elapsed(started_at.elapsed())
     ));
     Ok(())
+}
+
+/// Builds the host macOS slice and runs the staged Swift package unit tests.
+pub fn test(sh: &Shell, ctx: &BuildContext) -> Result<()> {
+    ensure_macos_host()?;
+    ensure_swift_sources(ctx)?;
+
+    let started_at = Instant::now();
+    let artifacts_dir = ctx.swift_artifacts_dir();
+    output::phase("Swift package tests");
+    output::path("Binding workspace", &ctx.bindings_swift_dir());
+    output::path("Package source", &ctx.swift_package_dir());
+    output::path("Artifact directory", &artifacts_dir);
+
+    let staging_dir = ctx.tmp_dir().join("swift");
+    prepare_output(sh, &staging_dir, &artifacts_dir)?;
+
+    let target_dir = ctx.cargo_swift_target_dir();
+    let host_slice = macos_slice_for_architecture(std::env::consts::ARCH)?;
+    let host_archive = build_archive(sh, ctx, &target_dir, host_slice)?;
+    let generated_dir = staging_dir.join("generated");
+    generate_bindings(sh, ctx, &host_archive, &generated_dir)?;
+    let package_dir = stage_package(sh, ctx, &generated_dir)?;
+    let xcframework = package_dir.join("Binary").join(SWIFT_XCFRAMEWORK_NAME);
+    create_xcframework(
+        sh,
+        &xcframework,
+        &generated_dir.join("Headers"),
+        &[&host_archive],
+    )?;
+
+    let _dir = sh.push_dir(&package_dir);
+    output::run_test_command(
+        "Running staged Swift package tests",
+        cmd!(sh, "{XCRUN_PATH} swift test"),
+    )
+    .context("staged Swift package tests failed")?;
+
+    output::success(format!(
+        "Swift package tests complete in {}",
+        output::elapsed(started_at.elapsed())
+    ));
+    Ok(())
+}
+
+fn macos_slice_for_architecture(architecture: &str) -> Result<AppleSlice> {
+    match architecture {
+        "aarch64" => Ok(MACOS_ARM64),
+        "x86_64" => Ok(MACOS_X86_64),
+        unsupported => anyhow::bail!(
+            "Swift package tests do not support macOS host architecture {unsupported}"
+        ),
+    }
 }
 
 fn ensure_macos_host() -> Result<()> {
@@ -231,9 +247,13 @@ fn ensure_swift_sources(ctx: &BuildContext) -> Result<()> {
         ctx.bindings_swift_dir().join("uniffi-bindgen.toml"),
         ctx.swift_package_dir().join("Package.swift"),
         ctx.swift_package_dir().join("Support/module.modulemap"),
-        ctx.swift_package_dir().join("Consumer/Package.swift"),
-        ctx.swift_package_dir()
-            .join("Consumer/Sources/SippConsumer/Consumer.swift"),
+        ctx.llama_cpp_dir().join("include/llama.h"),
+    ];
+    validate_required_sources(&required, "Swift build")
+}
+
+fn ensure_swift_example_sources(ctx: &BuildContext) -> Result<()> {
+    let required = [
         ctx.workspace_root().join("examples/swift/README.md"),
         ctx.workspace_root()
             .join("examples/swift/cli/Package.swift"),
@@ -256,11 +276,14 @@ fn ensure_swift_sources(ctx: &BuildContext) -> Result<()> {
         ctx.workspace_root()
             .join("examples/swift/ios/SippIOSApp.swift"),
         ctx.workspace_root().join("examples/swift/ios/Info.plist"),
-        ctx.llama_cpp_dir().join("include/llama.h"),
     ];
+    validate_required_sources(&required, "Swift example")
+}
+
+fn validate_required_sources(required: &[PathBuf], label: &str) -> Result<()> {
     for path in required {
         if !path.is_file() {
-            anyhow::bail!("required Swift build input is missing: {}", path.display());
+            anyhow::bail!("required {label} input is missing: {}", path.display());
         }
     }
     Ok(())
@@ -392,6 +415,25 @@ fn create_universal_archive(
     Ok(output_archive)
 }
 
+fn create_xcframework(
+    sh: &Shell,
+    xcframework: &Path,
+    headers_dir: &Path,
+    archives: &[&Path],
+) -> Result<()> {
+    let mut command = cmd!(sh, "{XCRUN_PATH} xcodebuild -create-xcframework");
+    for archive in archives {
+        command = command
+            .arg("-library")
+            .arg(archive)
+            .arg("-headers")
+            .arg(headers_dir);
+    }
+    command = command.arg("-output").arg(xcframework);
+    output::run_build_command("Creating SippCore.xcframework", command)
+        .context("failed to create SippCore.xcframework")
+}
+
 fn stage_package(sh: &Shell, ctx: &BuildContext, generated_dir: &Path) -> Result<PathBuf> {
     let source = ctx.swift_package_dir();
     let destination = ctx.swift_package_artifacts_dir();
@@ -447,51 +489,6 @@ fn copy_dir_recursive(source: &Path, destination: &Path) -> Result<()> {
                 )
             })?;
         }
-    }
-    Ok(())
-}
-
-fn validate_identical_directories(first: &Path, second: &Path) -> Result<()> {
-    let first_files = directory_file_contents(first)?;
-    let second_files = directory_file_contents(second)?;
-    if first_files != second_files {
-        anyhow::bail!(
-            "Swift binding generation was not deterministic between {} and {}",
-            first.display(),
-            second.display()
-        );
-    }
-    output::success("Swift binding generation is deterministic");
-    Ok(())
-}
-
-fn directory_file_contents(root: &Path) -> Result<BTreeMap<PathBuf, Vec<u8>>> {
-    let mut files = BTreeMap::new();
-    collect_directory_file_contents(root, root, &mut files)?;
-    Ok(files)
-}
-
-fn collect_directory_file_contents(
-    root: &Path,
-    directory: &Path,
-    files: &mut BTreeMap<PathBuf, Vec<u8>>,
-) -> Result<()> {
-    for entry in fs::read_dir(directory)
-        .with_context(|| format!("failed to read {}", directory.display()))?
-    {
-        let entry = entry?;
-        let path = entry.path();
-        if entry.file_type()?.is_dir() {
-            collect_directory_file_contents(root, &path, files)?;
-            continue;
-        }
-        let relative = path
-            .strip_prefix(root)
-            .with_context(|| format!("failed to relativize {}", path.display()))?
-            .to_path_buf();
-        let contents = fs::read(&path)
-            .with_context(|| format!("failed to read generated file {}", path.display()))?;
-        files.insert(relative, contents);
     }
     Ok(())
 }
@@ -622,6 +619,53 @@ fn validate_ffi_symbol_sets(
             unexpected.join(", ")
         );
     }
+    Ok(())
+}
+
+fn validate_package_platforms(sh: &Shell, ctx: &BuildContext, package_dir: &Path) -> Result<()> {
+    let validation_dir = ctx.swift_artifacts_dir().join("platform-validation");
+    for (name, destination) in SWIFT_PACKAGE_DESTINATIONS {
+        let derived_data = validation_dir.join(name);
+        let _dir = sh.push_dir(package_dir);
+        output::run_build_command(
+            format!("Building staged Swift package for {name}"),
+            cmd!(
+                sh,
+                "{XCRUN_PATH} xcodebuild -quiet -scheme {SWIFT_PACKAGE_SCHEME} -configuration Release -destination {destination} -derivedDataPath {derived_data} CODE_SIGNING_ALLOWED=NO build"
+            ),
+        )
+        .with_context(|| format!("staged Swift package failed to build for {name}"))?;
+    }
+    Ok(())
+}
+
+fn build_examples(sh: &Shell, ctx: &BuildContext) -> Result<()> {
+    let examples_source = ctx.workspace_root().join("examples/swift");
+    let examples_dir = ctx.swift_artifacts_dir().join("examples");
+    let cli_dir = examples_dir.join("cli");
+    copy_dir_recursive(&examples_source.join("cli"), &cli_dir)?;
+    let built_cli = build_swift_executable_package(sh, &cli_dir, SWIFT_CLI_NAME)?;
+    let cli_executable = examples_dir.join(SWIFT_CLI_NAME);
+    fs::copy(&built_cli, &cli_executable).with_context(|| {
+        format!(
+            "failed to stage Swift CLI from {} to {}",
+            built_cli.display(),
+            cli_executable.display()
+        )
+    })?;
+    validate_dynamic_linkage(sh, &cli_executable)?;
+
+    let swiftui_dir = examples_dir.join("swiftui");
+    copy_dir_recursive(&examples_source.join("swiftui"), &swiftui_dir)?;
+    let swiftui_executable = build_swift_executable_package(sh, &swiftui_dir, SWIFT_SANDBOX_NAME)?;
+    validate_dynamic_linkage(sh, &swiftui_executable)?;
+    let sandbox_app =
+        bundle_and_sign_sandbox_app(sh, &swiftui_dir, &swiftui_executable, &examples_dir)?;
+    let ios_app = build_ios_example(sh, ctx)?;
+
+    output::artifact(&cli_executable);
+    output::artifact(&sandbox_app);
+    output::artifact(&ios_app);
     Ok(())
 }
 

--- a/xtask/src/test.rs
+++ b/xtask/src/test.rs
@@ -102,12 +102,8 @@ const NODE_PACKAGE_SOURCE_ROOTS: &[&str] = &[
     "lib/node/router.d.ts",
 ];
 const PYTHON_PACKAGE_SOURCE_ROOTS: &[&str] = &["lib/python/python/sipp", "lib/python/backends"];
-const SWIFT_PACKAGE_SOURCE_ROOTS: &[&str] = &[
-    "bindings/swift",
-    "examples/swift",
-    "lib/swift",
-    "tools/uniffi-bindgen-swift",
-];
+const SWIFT_PACKAGE_SOURCE_ROOTS: &[&str] =
+    &["bindings/swift", "lib/swift", "tools/uniffi-bindgen-swift"];
 const CLI_SMOKE_SOURCE_ROOTS: &[&str] = &["apps/cli/src"];
 const RUST_SMOKE_SOURCE_ROOTS: &[&str] = &["examples/rust/src"];
 const NODE_SMOKE_SOURCE_ROOTS: &[&str] = &["examples/node", "lib/node"];
@@ -251,8 +247,8 @@ const TEST_SUITES: &[TestSuite] = &[
         id: TestSuiteId::SwiftPackage,
         group: TestGroup::Unit,
         layer: Some(TestUnitLayer::Interface),
-        description: "Apple Swift package, macOS examples, and artifact tests",
-        requirements: "macOS, Xcode, cargo, Rust Apple targets",
+        description: "Apple Swift package unit tests",
+        requirements: "macOS, Xcode, cargo, Rust host target",
         source_roots: SWIFT_PACKAGE_SOURCE_ROOTS,
         coverage: false,
         backend_policy: BackendPolicy::None,
@@ -567,7 +563,7 @@ fn run_suite(
         SuiteRunner::PythonPackage => {
             run_python_package_tests(sh, ctx, &options.backend, options.coverage)
         }
-        SuiteRunner::SwiftPackage => targets::swift::build(sh, ctx),
+        SuiteRunner::SwiftPackage => targets::swift::test(sh, ctx),
         SuiteRunner::CliSmoke => run_cli_model_smoke(sh, ctx, options),
         SuiteRunner::RustSmoke => run_rust_model_smoke(sh, ctx, options),
         SuiteRunner::NodeSmoke => run_node_model_smoke(sh, ctx, options),

--- a/xtask/src/tests/cli_tests.rs
+++ b/xtask/src/tests/cli_tests.rs
@@ -21,8 +21,20 @@ fn build_commands_parse_backend_defaults_and_overrides() {
     let Commands::Build { target } = cli.command else {
         panic!("expected build command");
     };
-    assert!(matches!(target, super::BuildCommands::Swift));
+    let super::BuildCommands::Swift(args) = target else {
+        panic!("expected Swift build");
+    };
+    assert!(!args.examples);
     assert!(Cli::try_parse_from(["xtask", "build", "swift", "--backend", "metal"]).is_err());
+
+    let cli = Cli::parse_from(["xtask", "build", "swift", "--examples"]);
+    let Commands::Build { target } = cli.command else {
+        panic!("expected build command");
+    };
+    let super::BuildCommands::Swift(args) = target else {
+        panic!("expected Swift build");
+    };
+    assert!(args.examples);
 
     let cli = Cli::parse_from(["xtask", "build", "node"]);
     let Commands::Build { target } = cli.command else {

--- a/xtask/src/tests/main_tests.rs
+++ b/xtask/src/tests/main_tests.rs
@@ -5,11 +5,11 @@
 
 use xtask::cli::{
     Backend, BackendArgs, BuildCommands, CleanArgs, Commands, RunCommands, RunGatewayServerArgs,
-    RunGatewayServerCommand, RunGatewayServerSourceArgs, TestCommands, TestGroupFilter,
-    TestListArgs, TestListFormat, TestSmokeArgs, TestSmokeCaseArgs, TestSmokeCommands,
-    TestSmokeModelArgs, TestSmokePlaygroundBrowserArgs, TestSmokeSuiteArgs, TestSmokeSuiteTarget,
-    TestUnitArgs, TestUnitCommands, TestUnitGroupArgs, TestUnitGroupTarget, TestVerifyArgs,
-    TestVerifyTarget, WasmBuildArgs, WasmRuntime, WasmThreading,
+    RunGatewayServerCommand, RunGatewayServerSourceArgs, SwiftBuildArgs, TestCommands,
+    TestGroupFilter, TestListArgs, TestListFormat, TestSmokeArgs, TestSmokeCaseArgs,
+    TestSmokeCommands, TestSmokeModelArgs, TestSmokePlaygroundBrowserArgs, TestSmokeSuiteArgs,
+    TestSmokeSuiteTarget, TestUnitArgs, TestUnitCommands, TestUnitGroupArgs, TestUnitGroupTarget,
+    TestVerifyArgs, TestVerifyTarget, WasmBuildArgs, WasmRuntime, WasmThreading,
 };
 
 use super::{
@@ -89,8 +89,12 @@ fn build_summary_labels_backend_defaults_and_explicit_backends() {
         "Build Node.js bindings (cpu)"
     );
     assert_eq!(
-        build_summary(&BuildCommands::Swift),
+        build_summary(&BuildCommands::Swift(Default::default())),
         "Build Apple Swift package"
+    );
+    assert_eq!(
+        build_summary(&BuildCommands::Swift(SwiftBuildArgs { examples: true })),
+        "Build Apple Swift package and examples"
     );
     assert_eq!(
         build_summary(&BuildCommands::Wasm(WasmBuildArgs {

--- a/xtask/src/tests/targets/swift_tests.rs
+++ b/xtask/src/tests/targets/swift_tests.rs
@@ -1,7 +1,7 @@
 //! Tests the `targets::swift` module in `xtask`.
 //!
-//! Covers deterministic generation, source staging, architecture, ABI,
-//! linkage, path construction, and platform gates without Apple toolchains.
+//! Covers source staging, architecture, ABI, linkage, path construction, and
+//! platform gates without Apple toolchains.
 
 use std::collections::BTreeSet;
 
@@ -9,11 +9,12 @@ use crate::test_support::TempDir;
 use crate::utils::BuildContext;
 
 use super::{
-    copy_dir_recursive, declared_ffi_symbols, ensure_macos_host, ensure_swift_sources,
-    exported_ffi_symbols, validate_architecture_list, validate_dynamic_linkage_output,
-    validate_ffi_symbol_sets, validate_identical_directories, validate_nm_diagnostics,
-    validate_sandbox_entitlements, AppleSlice, SliceBackend, IOS_ARM64, IOS_SIMULATOR_ARM64,
-    IOS_SIMULATOR_X86_64, MACOS_ARM64, MACOS_X86_64,
+    copy_dir_recursive, declared_ffi_symbols, ensure_macos_host, ensure_swift_example_sources,
+    ensure_swift_sources, exported_ffi_symbols, macos_slice_for_architecture,
+    validate_architecture_list, validate_dynamic_linkage_output, validate_ffi_symbol_sets,
+    validate_nm_diagnostics, validate_sandbox_entitlements, AppleSlice, SliceBackend, IOS_ARM64,
+    IOS_SIMULATOR_ARM64, IOS_SIMULATOR_X86_64, MACOS_ARM64, MACOS_X86_64,
+    SWIFT_PACKAGE_DESTINATIONS,
 };
 
 #[test]
@@ -79,7 +80,7 @@ fn recursive_copy_preserves_package_tree() {
 }
 
 #[test]
-fn source_validation_requires_binding_package_examples_and_submodule() {
+fn source_validation_requires_binding_package_and_submodule() {
     let temp = TempDir::new("target-swift-inputs");
     let ctx = BuildContext::from_workspace_root_for_test(temp.path());
 
@@ -91,8 +92,19 @@ fn source_validation_requires_binding_package_examples_and_submodule() {
     temp.write("bindings/swift/uniffi-bindgen.toml", "");
     temp.write("lib/swift/Package.swift", "");
     temp.write("lib/swift/Support/module.modulemap", "");
-    temp.write("lib/swift/Consumer/Package.swift", "");
-    temp.write("lib/swift/Consumer/Sources/SippConsumer/Consumer.swift", "");
+    temp.write("crates/sys/llama.cpp/include/llama.h", "");
+
+    ensure_swift_sources(&ctx).unwrap();
+}
+
+#[test]
+fn example_source_validation_is_separate_from_distribution_inputs() {
+    let temp = TempDir::new("target-swift-example-inputs");
+    let ctx = BuildContext::from_workspace_root_for_test(temp.path());
+
+    let error = ensure_swift_example_sources(&ctx).unwrap_err();
+    assert!(error.to_string().contains("example"));
+
     temp.write("examples/swift/README.md", "");
     temp.write("examples/swift/cli/Package.swift", "");
     temp.write("examples/swift/cli/Sources/SippCLI/SippCLI.swift", "");
@@ -114,9 +126,8 @@ fn source_validation_requires_binding_package_examples_and_submodule() {
     temp.write("examples/swift/ios/SippIOS.xcodeproj/project.pbxproj", "");
     temp.write("examples/swift/ios/SippIOSApp.swift", "");
     temp.write("examples/swift/ios/Info.plist", "");
-    temp.write("crates/sys/llama.cpp/include/llama.h", "");
 
-    ensure_swift_sources(&ctx).unwrap();
+    ensure_swift_example_sources(&ctx).unwrap();
 }
 
 #[test]
@@ -130,24 +141,35 @@ fn host_gate_matches_the_current_operating_system() {
 }
 
 #[test]
-fn deterministic_generation_requires_identical_paths_and_bytes() {
-    let temp = TempDir::new("target-swift-determinism");
-    let first = temp.create_dir("first");
-    let second = temp.create_dir("second");
-    temp.write("first/SippCoreBindings.swift", "generated\n");
-    temp.write("second/SippCoreBindings.swift", "generated\n");
-
-    validate_identical_directories(&first, &second).unwrap();
-
-    temp.write("second/SippCoreBindings.swift", "changed\n");
-    assert!(validate_identical_directories(&first, &second).is_err());
-}
-
-#[test]
 fn architecture_validation_requires_the_exact_slice_set() {
     validate_architecture_list("x86_64 arm64\n", &["arm64", "x86_64"]).unwrap();
     assert!(validate_architecture_list("arm64\n", &["arm64", "x86_64"]).is_err());
     assert!(validate_architecture_list("arm64 x86_64 i386\n", &["arm64", "x86_64"]).is_err());
+}
+
+#[test]
+fn host_architecture_selects_one_macos_slice() {
+    assert_eq!(
+        macos_slice_for_architecture("aarch64").unwrap(),
+        MACOS_ARM64
+    );
+    assert_eq!(
+        macos_slice_for_architecture("x86_64").unwrap(),
+        MACOS_X86_64
+    );
+    assert!(macos_slice_for_architecture("powerpc").is_err());
+}
+
+#[test]
+fn distribution_validates_each_supported_platform_family() {
+    assert_eq!(
+        SWIFT_PACKAGE_DESTINATIONS,
+        [
+            ("macos", "generic/platform=macOS"),
+            ("ios", "generic/platform=iOS"),
+            ("ios-simulator", "generic/platform=iOS Simulator"),
+        ]
+    );
 }
 
 #[test]

--- a/xtask/src/tests/test_tests.rs
+++ b/xtask/src/tests/test_tests.rs
@@ -955,7 +955,7 @@ fn source_path_helpers_classify_roots_and_tests() {
             .iter()
             .map(|suite| suite.id)
             .collect::<Vec<_>>(),
-        vec![TestSuiteId::SwiftPackage]
+        Vec::<TestSuiteId>::new()
     );
     assert!(is_first_party_source_path("xtask/src/test.rs"));
     assert!(is_first_party_source_path(


### PR DESCRIPTION
This PR publishes generated Swift packages and XCFramework releases to another repo, Sipp-Swift, and adds Swift testing to gate dev/stable publishing on successful builds. Therefore, we keep Sipp as the sole source.